### PR TITLE
transmission love

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+    "env": {
+        "es6": true,
+        "browser": true
+    },
+    "extends": ["eslint:recommended"],
+    "parserOptions": {
+        "ecmaVersion": 2017,
+        "sourceType": "module"
+    },
+    "rules": {
+        "no-console": "off",
+        "semi": 2,
+        "no-unused-vars": "warn"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libhoney",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "Javascript library for sending data to Honeycomb",
   "bugs": "https://github.com/honeycombio/libhoney-js/issues",
   "repository": {

--- a/src/builder.js
+++ b/src/builder.js
@@ -142,4 +142,4 @@ export default class Builder {
 
     return b;
   }
-};
+}

--- a/src/builder.js
+++ b/src/builder.js
@@ -22,6 +22,37 @@ export default class Builder {
     this._fields = Object.create(null);
     this._dyn_fields = Object.create(null);
 
+    /**
+     * The hostname for the Honeycomb API server to which to send events created through this
+     * builder.  default: https://api.honeycomb.io/
+     *
+     * @type {string}
+     */
+    this.apiHost = "";
+    /**
+     * The Honeycomb authentication token. If it is set on a libhoney instance it will be used as the
+     * default write key for all events. If absent, it must be explicitly set on a Builder or
+     * Event. Find your team write key at https://ui.honeycomb.io/account
+     *
+     * @type {string}
+     */
+    this.writeKey = "";
+    /**
+     * The name of the Honeycomb dataset to which to send these events.  If it is specified during
+     * libhoney initialization, it will be used as the default dataset for all events. If absent,
+     * dataset must be explicitly set on a builder or event.
+     *
+     * @type {string}
+     */
+    this.dataset = "";
+    /**
+     * The rate at which to sample events. Default is 1, meaning no sampling. If you want to send one
+     * event out of every 250 times send() is called, you would specify 250 here.
+     *
+     * @type {number}
+     */
+    this.sampleRate = 1;
+
     foreach(fields, (v,k) => this.addField(k, v));
     foreach(dyn_fields, (v,k) => this.addDynamicField(k, v));
   }

--- a/src/event.js
+++ b/src/event.js
@@ -22,6 +22,33 @@ export default class Event {
     this.data = Object.create(null);
     this.metadata = null;
 
+    /**
+     * The hostname for the Honeycomb API server to which to send this event.  default:
+     * https://api.honeycomb.io/
+     *
+     * @type {string}
+     */
+    this.apiHost = "";
+    /**
+     * The Honeycomb authentication token for this event.  Find your team write key at
+     * https://ui.honeycomb.io/account
+     *
+     * @type {string}
+     */
+    this.writeKey = "";
+    /**
+     * The name of the Honeycomb dataset to which to send this event.
+     *
+     * @type {string}
+     */
+    this.dataset = "";
+    /**
+     * The rate at which to sample this event.
+     *
+     * @type {number}
+     */
+    this.sampleRate = 1;
+
     foreach(fields, (v, k) => this.addField(k, v));
     foreach(dyn_fields, (v, k) => this.addField(k, v()));
 

--- a/src/event.js
+++ b/src/event.js
@@ -92,4 +92,4 @@ export default class Event {
   send () {
     this._libhoney.sendEvent(this);
   }
-};
+}

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -63,30 +63,82 @@ export default class Libhoney {
     this._builder.sampleRate = this._options.sampleRate;
   }
 
+  /**
+   * The hostname for the Honeycomb API server to which to send events created through this libhoney
+   * instance. default: https://api.honeycomb.io/
+   *
+   * @type {string}
+   */
   set apiHost(v) {
     this._builder.apiHost = v;
   }
+  /**
+   * The hostname for the Honeycomb API server to which to send events created through this libhoney
+   * instance. default: https://api.honeycomb.io/
+   *
+   * @type {string}
+   */
   get apiHost() {
     return this._builder.apiHost;
   }
 
+  /**
+   * The Honeycomb authentication token. If it is set on a libhoney instance it will be used as the
+   * default write key for all events. If absent, it must be explicitly set on a Builder or
+   * Event. Find your team write key at https://ui.honeycomb.io/account
+   *
+   * @type {string}
+   */
   set writeKey(v) {
     this._builder.writeKey = v;
   }
+  /**
+   * The Honeycomb authentication token. If it is set on a libhoney instance it will be used as the
+   * default write key for all events. If absent, it must be explicitly set on a Builder or
+   * Event. Find your team write key at https://ui.honeycomb.io/account
+   *
+   * @type {string}
+   */
   get writeKey() {
     return this._builder.writeKey;
   }
 
+  /**
+   * The name of the Honeycomb dataset to which to send events through this libhoney instance.  If
+   * it is specified during libhoney initialization, it will be used as the default dataset for all
+   * events. If absent, dataset must be explicitly set on a builder or event.
+   *
+   * @type {string}
+   */
   set dataset(v) {
     this._builder.dataset = v;
   }
+  /**
+   * The name of the Honeycomb dataset to which to send these events through this libhoney instance.
+   * If it is specified during libhoney initialization, it will be used as the default dataset for
+   * all events. If absent, dataset must be explicitly set on a builder or event.
+   *
+   * @type {string}
+   */
   get dataset() {
     return this._builder.dataset;
   }
 
+  /**
+   * The rate at which to sample events. Default is 1, meaning no sampling. If you want to send one
+   * event out of every 250 times send() is called, you would specify 250 here.
+   *
+   * @type {number}
+   */
   set sampleRate(v) {
     this._builder.sampleRate = v;
   }
+  /**
+   * The rate at which to sample events. Default is 1, meaning no sampling. If you want to send one
+   * event out of every 250 times send() is called, you would specify 250 here.
+   *
+   * @type {number}
+   */
   get sampleRate() {
     return this._builder.sampleRate;
   }

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -7,8 +7,6 @@
  */
 import Transmission from './transmission';
 import Builder from './builder';
-import Event from './event';
-import foreach from './foreach';
 
 const defaults = Object.freeze({
   // host to send data to
@@ -26,8 +24,15 @@ const defaults = Object.freeze({
   transmission: "base",
 
   // batch triggers
-  batchSizeTrigger: 100, // we send a batch to the api when we have this many outstanding events
-  batchTimeTrigger: 100 // ... or after this many ms has passed.
+  batchSizeTrigger: 50,  // we send a batch to the api when we have this many outstanding events
+  batchTimeTrigger: 100, // ... or after this many ms has passed.
+
+  // batches are sent serially (one event at a time), so we allow multiple concurrent batches
+  // to increase parallelism while sending.
+  maxConcurrentBatches: 10,
+
+  // the maximum number of pending events we allow in our queue before they get batched
+  pendingWorkCapacity: 10000
 });
 
 /**

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the Apache License 2.0
 // license that can be found in the LICENSE file.
 
+/* global require, window, global */
+
 /**
  * @module
  */
@@ -10,11 +12,27 @@ import urljoin from 'urljoin';
 
 const libhoney_js_version = "LIBHONEY_JS_VERSION";
 
-// default triggers for sending a batch:
-const batchSizeTrigger = 100; // either when the eventQueue is > this length
+const _global = (typeof window !== "undefined" ? window :
+                 typeof global !== "undefined" ? global : undefined);
+
+// how many events to collect in a batch
+const batchSizeTrigger = 50;  // either when the eventQueue is > this length
 const batchTimeTrigger = 100; // or it's been more than this many ms since the first push
 
+// how many batches to maintain in parallel
+const maxConcurrentBatches = 10;
+
+// how many events to queue up for busy batches before we start dropping
+const pendingWorkCapacity = 10000;
+
 const emptyResponseCallback = function() { };
+
+const eachSeries = (arr, iteratorFn) =>
+    arr.reduce(function(p, item) {
+        return p.then(function() {
+            return iteratorFn(item);
+        });
+    }, Promise.resolve());
 
 /**
  * @private
@@ -25,8 +43,11 @@ export default class Transmission {
     this._responseCallback = emptyResponseCallback;
     this._batchSizeTrigger = batchSizeTrigger;
     this._batchTimeTrigger = batchTimeTrigger;
+    this._maxConcurrentBatches = maxConcurrentBatches;
+    this._pendingWorkCapacity = pendingWorkCapacity;
     this._sendTimeoutId = -1;
     this._eventQueue = [];
+    this._batchCount = 0;
     // Included for testing; to stub out randomness and verify that an event
     // was dropped.
     this._randomFn = Math.random;
@@ -40,6 +61,12 @@ export default class Transmission {
     }
     if (typeof options.batchTimeTrigger == "number") {
       this._batchTimeTrigger = options.batchTimeTrigger;
+    }
+    if (typeof options.maxConcurrentBatches == "number") {
+      this._maxConcurrentBatches = options.maxConcurrentBatches;
+    }
+    if (typeof options.pendingWorkCapacity == "number") {
+      this._pendingWorkCapacity = options.pendingWorkCapacity;
     }
   }
 
@@ -59,28 +86,56 @@ export default class Transmission {
   }
 
   _sendBatch () {
+    if (this._batchCount == maxConcurrentBatches) {
+      // don't start up another concurrent batch.  the next timeout/sendEvent or batch completion
+      // will cause us to send another
+      return;
+    }
+
     this._clearSendTimeout();
+
+    this._batchCount++;
 
     var batch = this._eventQueue.splice(0, this._batchSizeTrigger);
 
-    for (var ev of batch) {
+    eachSeries(batch, (ev) => {
       var url = urljoin(ev.apiHost, "/1/events", ev.dataset);
       var req = superagent.post(url);
-      req
-        .set('X-Hny-Team', ev.writeKey)
-        .set('X-Hny-Samplerate', ev.sampleRate)
-        .set('X-Hny-Event-Time', ev.timestamp.toISOString())
-        .set('User-Agent', `libhoney-js/${libhoney_js_version}`)
-        .type("json")
-        .send(ev.postData)
-        .end((err, res) => {
-          // call a callback here (in our init options) so it can be used both in the node, browser, and worker contexts.
-          this._responseCallback({ stuff: "goes here" }); // XXX(toshok)
-        });
-    }
+
+      return new Promise( (resolve) => {
+        req
+          .set('X-Hny-Team', ev.writeKey)
+          .set('X-Hny-Samplerate', ev.sampleRate)
+          .set('X-Hny-Event-Time', ev.timestamp.toISOString())
+          .set('User-Agent', `libhoney-js/${libhoney_js_version}`)
+          .type("json")
+          .send(ev.postData)
+          .end((err, res) => {
+            // call a callback here (in our init options) so it can be used both in the node, browser, and worker contexts.
+            this._responseCallback({ err, res });
+
+            // we resolve unconditionally to continue the iteration in eachSeries.  errors will cause
+            // the event to be re-enqueued/dropped.
+            resolve();
+          });
+      });
+    }).then( () => {
+      this._batch--;
+      if (this._eventQueue.length > this._batchSizeTrigger) {
+        this._sendBatch();
+      }
+    }).catch( () => {
+      this._batch--;
+      if (this._eventQueue.length > this._batchSizeTrigger) {
+        this._sendBatch();
+      }
+    });
   }
 
   _shouldSendEvent (ev) {
+    if (this._eventQueue.length >= this._pendingWorkCapacity) {
+      return false;
+    }
     var { sampleRate } = ev;
     if (sampleRate <= 1) {
       return true;
@@ -90,13 +145,13 @@ export default class Transmission {
 
   _ensureSendTimeout () {
     if (this._sendTimeoutId === -1) {
-      this._sendTimeoutId = setTimeout(() => this._sendBatch(), this._batchTimeTrigger);
+      this._sendTimeoutId = _global.setTimeout(() => this._sendBatch(), this._batchTimeTrigger);
     }
   }
 
   _clearSendTimeout () {
     if (this._sendTimeoutId !== -1) {
-      clearTimeout(this._sendTimeoutId);
+      _global.clearTimeout(this._sendTimeoutId);
       this._sendTimeoutId = -1;
     }
   }

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -10,7 +10,7 @@
 let superagent = require('superagent');
 import urljoin from 'urljoin';
 
-const libhoney_js_version = "LIBHONEY_JS_VERSION";
+const userAgent = "libhoney-js/LIBHONEY_JS_VERSION";
 
 const _global = (typeof window !== "undefined" ? window :
                  typeof global !== "undefined" ? global : undefined);
@@ -27,7 +27,7 @@ const pendingWorkCapacity = 10000;
 
 const emptyResponseCallback = function() { };
 
-const eachSeries = (arr, iteratorFn) =>
+const eachPromise = (arr, iteratorFn) =>
     arr.reduce(function(p, item) {
         return p.then(function() {
             return iteratorFn(item);
@@ -98,7 +98,7 @@ export default class Transmission {
 
     var batch = this._eventQueue.splice(0, this._batchSizeTrigger);
 
-    eachSeries(batch, (ev) => {
+    eachPromise(batch, (ev) => {
       var url = urljoin(ev.apiHost, "/1/events", ev.dataset);
       var req = superagent.post(url);
 
@@ -107,7 +107,7 @@ export default class Transmission {
           .set('X-Hny-Team', ev.writeKey)
           .set('X-Hny-Samplerate', ev.sampleRate)
           .set('X-Hny-Event-Time', ev.timestamp.toISOString())
-          .set('User-Agent', `libhoney-js/${libhoney_js_version}`)
+          .set('User-Agent', userAgent)
           .type("json")
           .send(ev.postData)
           .end((err, res) => {

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -1,3 +1,4 @@
+/* global describe, it */
 import assert from 'assert';
 import libhoney from '../lib/libhoney';
 

--- a/test/event_test.js
+++ b/test/event_test.js
@@ -1,3 +1,4 @@
+/* global describe, it */
 import assert from 'assert';
 import libhoney from '../lib/libhoney';
 
@@ -22,7 +23,8 @@ describe('libhoney events', function() {
     var ev2 = b.newEvent();
     var map = new Map();
     map.set("a", 5);
-    assert.equal(5, ev.data.a);
+    ev2.add(map);
+    assert.equal(5, ev2.data.a);
   });
 
   it("it toString()'s keys from Maps in .add()", function() {
@@ -60,7 +62,7 @@ describe('libhoney events', function() {
     map.set("boolean", true);
 
     // Date does not convert
-    var d = new Date(1,2,3,4,5,6,7)
+    var d = new Date(1,2,3,4,5,6,7);
     map.set("Date", d);
 
     // Null/undefined both end up being null in the output

--- a/test/libhoney_test.js
+++ b/test/libhoney_test.js
@@ -1,3 +1,4 @@
+/* global describe, it */
 import assert from 'assert';
 import libhoney from '../lib/libhoney';
 
@@ -7,7 +8,8 @@ describe('libhoney', function() {
   describe("constructor options", function() {
     it("should be communicated to transmission constructor", function() {
       var options = { a: 1, b: 2, c: 3, d: 4, transmission: MockTransmission };
-      var honey = new libhoney(options);
+
+      new libhoney(options);
 
       assert.equal(options.a, _transmissionConstructorArg.a);
       assert.equal(options.b, _transmissionConstructorArg.b);

--- a/test/transmission_test.js
+++ b/test/transmission_test.js
@@ -1,3 +1,4 @@
+/* global require, describe, it */
 import assert from 'assert';
 import Transmission from '../lib/transmission';
 
@@ -57,7 +58,7 @@ describe('transmission', function() {
       }
     });
 
-    transmission._randomFn = function() { return 0.09 };
+    transmission._randomFn = function() { return 0.09; };
     transmission.sendEvent({
       apiHost: "http://localhost:9999",
       writeKey: "123456789",
@@ -86,5 +87,126 @@ describe('transmission', function() {
       timestamp: new Date(),
       postData: JSON.stringify({ a: 1, b: 2 })
     });
+  });
+
+  it('should drop events beyond the pendingWorkCapacity', function(done) {
+    var eventDropped;
+    var droppedExpected = 5;
+    var responseCount = 0;
+    var responseExpected = 5;
+
+    mock.post('http://localhost:9999/1/events/test-transmission', function(req) {
+      return {};
+    });
+
+    var transmission = new Transmission({
+      batchTimeTrigger: 50,
+      pendingWorkCapacity: responseExpected,
+      responseCallback () {
+        responseCount ++;
+        if (responseCount == responseExpected) {
+          done();
+        }
+      }
+    });
+
+    transmission._droppedCallback = function() {
+      eventDropped = true;
+    };
+
+    // send the events we expect responses for
+    for (let i = 0; i < responseExpected; i ++) {
+      transmission.sendEvent({
+        apiHost: "http://localhost:9999",
+        writeKey: "123456789",
+        dataset: "test-transmission",
+        sampleRate: 1,
+        timestamp: new Date(),
+        postData: JSON.stringify({ a: 1, b: 2 })
+      });
+    }
+
+    // send the events we expect to drop.  Since JS is single threaded we can verify that
+    // droppedCount behaves the way we want
+    for (let i = 0; i < droppedExpected; i ++) {
+      eventDropped = false;
+      transmission.sendEvent({
+        apiHost: "http://localhost:9999",
+        writeKey: "123456789",
+        dataset: "test-transmission",
+        sampleRate: 1,
+        timestamp: new Date(),
+        postData: JSON.stringify({ a: 1, b: 2 })
+      });
+      assert.equal(true, eventDropped);
+    }
+  });
+
+  it('should send the right number events even if it requires multiple concurrent batches', function(done) {
+    var responseCount = 0;
+    var responseExpected = 10;
+
+    mock.post('http://localhost:9999/1/events/test-transmission', function(req) {
+      return {};
+    });
+
+    var transmission = new Transmission({
+      batchTimeTrigger: 50,
+      batchSizeTrigger: 5,
+      pendingWorkCapacity: responseExpected,
+      responseCallback () {
+        responseCount ++;
+        if (responseCount == responseExpected) {
+          done();
+        }
+      }
+    });
+
+    for (let i = 0; i < responseExpected; i ++) {
+      transmission.sendEvent({
+        apiHost: "http://localhost:9999",
+        writeKey: "123456789",
+        dataset: "test-transmission",
+        sampleRate: 1,
+        timestamp: new Date(),
+        postData: JSON.stringify({ a: 1, b: 2 })
+      });
+    }
+  });
+
+  it('should send the right number of events even if they all fail', function(done) {
+    var responseCount = 0;
+    var responseExpected = 10;
+
+    mock.post('http://localhost:9999/1/events/test-transmission', function(req) {
+      return {
+        status: 404
+      };
+    });
+
+    var transmission = new Transmission({
+      batchTimeTrigger: 50,
+      batchSizeTrigger: 5,
+      maxConcurrentBatches: 1,
+      pendingWorkCapacity: responseExpected,
+      responseCallback ({ err }) {
+        assert.equal(404, err.status);
+        responseCount ++;
+        if (responseCount == responseExpected) {
+          done();
+        }
+      }
+    });
+
+    for (let i = 0; i < responseExpected; i ++) {
+      transmission.sendEvent({
+        apiHost: "http://localhost:9999",
+        writeKey: "123456789",
+        dataset: "test-transmission",
+        sampleRate: 1,
+        timestamp: new Date(),
+        postData: JSON.stringify({ a: 1, b: 2 })
+      });
+    }
   });
 });


### PR DESCRIPTION
add concurrent batches (serially sending events within a batch) instead of doing one concurrent send per event in the batch.
    
Before this change we would start sending a batch once one of the triggers (# events/timeout) fired, but we'd make N calls req.send at once.
    
This change instead works through an individual batch serially, sending one event then the next.
    
Concurrency is managed by permitting multiple batches to be processed at the same time, up to `maxConcurrentBatches` (default 10.)
    
also before this change our `eventQueue` could grow without bound if processing events was slow.
This change adds `pendingWorkCapacity` (default 10000) which is the max size of the pending event queue before we start dropping events.
    
This brings the behavior of the JS SDK a little closer in line with the other SDKs.  There is still no blocking on send/response, as that doesn't really work in the JS context.
