### PR TITLE
Batch size trigger fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libhoney",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Javascript library for sending data to Honeycomb",
   "bugs": "https://github.com/honeycombio/libhoney-js/issues",
   "repository": {

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -57,7 +57,7 @@ export default class Transmission {
       this._responseCallback = options.responseCallback;
     }
     if (typeof options.batchSizeTrigger == "number") {
-      this._batchSizeTrigger = options.batchSizeTrigger;
+      this._batchSizeTrigger = Math.max(options.batchSizeTrigger, 1);
     }
     if (typeof options.batchTimeTrigger == "number") {
       this._batchTimeTrigger = options.batchTimeTrigger;
@@ -78,7 +78,7 @@ export default class Transmission {
     }
 
     this._eventQueue.push(ev);
-    if (this._eventQueue.length > this._batchSizeTrigger) {
+    if (this._eventQueue.length >= this._batchSizeTrigger) {
       this._sendBatch();
     } else {
       this._ensureSendTimeout();
@@ -103,7 +103,7 @@ export default class Transmission {
 
       let queueLength = this._eventQueue.length;
       if (queueLength > 0) {
-        if (queueLength > this._batchSizeTrigger) {
+        if (queueLength >= this._batchSizeTrigger) {
           this._sendBatch();
         } else {
           this._ensureSendTimeout();


### PR DESCRIPTION
The size trigger should activate on >=, not >, so a batchSizeTrigger of N means sending N events will trigger the batch, not N+1.
    
Ensure that batchSizeTrigger is clamped to >= 1.