### PR TITLE
add .disabled flag to libhoney constructor options

### DIFF
--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -34,7 +34,10 @@ const defaults = Object.freeze({
   pendingWorkCapacity: 10000,
 
   // the maximum number of s we enqueue before we drop.
-  maxResponseQueueSize: 1000
+  maxResponseQueueSize: 1000,
+
+  // if this is false, all sending is disabled.  useful for disabling libhoney when testing
+  disabled: false
 });
 
 /**
@@ -395,6 +398,10 @@ export default class Libhoney extends EventEmitter {
 }
 
 function getAndInitTransmission(transmission, options) {
+  if (options.disabled) {
+    return null;
+  }
+
   if (typeof transmission === "string") {
     if (transmission === "base") {
       transmission = Transmission;

--- a/test/mock_transmission.js
+++ b/test/mock_transmission.js
@@ -1,6 +1,11 @@
 export let _transmissionConstructorArg = null;
 export let _transmissionSendEventArg = null;
 
+export const resetArgs = () => {
+  _transmissionConstructorArg = null;
+  _transmissionSendEventArg = null;
+};
+
 export class MockTransmission {
   constructor(options) {
     _transmissionConstructorArg = options;


### PR DESCRIPTION
if `disabled` is `true` we disable the transmission entirely.

libhoney already has the means of disabling hitting the transmission implementation (`this._usable`).  we piggyback off this and have `getAndInitTransmission` return null in the case `options.disable` is true.

Should address #9 