### PR TITLE
Stop `stringify`ing JS objects now that we can unroll on the server

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -99,14 +99,7 @@ export default class Event {
    *     .send();
    */
   addField (name, val) {
-    if (typeof val === "object") {
-      // JS reports typeof == object for a lot of things that we don't need additional processing to handle
-      if (val === null || val instanceof Boolean || val instanceof Number || val instanceof Date || val instanceof String) {
-        // these are fine
-      } else {
-        val = JSON.stringify(val);
-      }
-    } else if (val == undefined) {
+    if (val == undefined) {
       val = null;
     }
     this.data[name] = val;

--- a/test/event_test.js
+++ b/test/event_test.js
@@ -46,7 +46,7 @@ describe('libhoney events', function() {
     ev = b.newEvent();
     map = new Map();
     
-    // Object, we JSON.stringify it
+    // Object, we pass it on through (and let Honeycomb serialize it if necessary)
     map.set("obj", { a: 1, b : 2 });
 
     // String converts to a string
@@ -71,6 +71,6 @@ describe('libhoney events', function() {
     
     ev.add(map);
 
-    assert.equal(JSON.stringify(ev.data), `{"obj":\"{\\"a\\":1,\\"b\\":2}\","String":"a:1","string":"a:1","Number":5,"number":5,"Boolean":true,"boolean":true,"Date":${ JSON.stringify(d) },"null":null,"undefined":null}`);
+    assert.equal(JSON.stringify(ev.data), `{"obj":{"a":1,"b":2},"String":"a:1","string":"a:1","Number":5,"number":5,"Boolean":true,"boolean":true,"Date":${ JSON.stringify(d) },"null":null,"undefined":null}`);
   });
 });


### PR DESCRIPTION
Groan. `stringify`ing them in the SDK prevents unrolling from being possible on the server. (Going to run through our other SDKs to see whether any of them also do this, cringe)