### PR TITLE
use /1/batch/<dataset> endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.11.6",
-    "esdoc": "^0.4.8",
+    "esdoc": "^0.5.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-esdoc": "^0.3.0",
@@ -35,8 +35,7 @@
     "gulp-replace": "^0.5.4",
     "jsdoc": "^3.4.0",
     "mocha": "^3.0.2",
-    "superagent-mocker": "^0.5.2",
-    "esdoc": "^0.5.2"
+    "superagent-mocker": "^0.5.2"
   },
   "dependencies": {
     "superagent": "^2.3.0",

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -6,7 +6,7 @@
 /**
  * @module
  */
-import Transmission from './transmission';
+import { Transmission, ValidatedEvent } from './transmission';
 import Builder from './builder';
 
 import { EventEmitter } from 'events';
@@ -39,38 +39,6 @@ const defaults = Object.freeze({
   // if this is set to true, all sending is disabled.  useful for disabling libhoney when testing
   disabled: false
 });
-
-class ValidatedEvent {
-  constructor(timestamp,
-              apiHost,
-              postData,
-              writeKey,
-              dataset,
-              sampleRate,
-              metadata) {
-    this.timestamp  = timestamp;
-    this.apiHost    = apiHost;
-    this.postData   = postData;
-    this.writeKey   = writeKey;
-    this.dataset    = dataset;
-    this.sampleRate = sampleRate;
-    this.metadata   = metadata;
-  }
-
-  toJSON() {
-    let fields = [];
-    if (this.timestamp) {
-      fields.push(`"time":${JSON.stringify(this.timestamp)}`);
-    }
-    if (this.sampleRate) {
-      fields.push(`"samplerate":${JSON.stringify(this.sampleRate)}`);
-    }
-    if (this.postData) {
-      fields.push(`"data":${this.postData}`);
-    }
-    return `{${fields.join(",")}}`;
-  }
-}
 
 /**
  * libhoney aims to make it as easy as possible to create events and send them on into Honeycomb.
@@ -307,13 +275,13 @@ export default class Libhoney extends EventEmitter {
     }
 
     var metadata = event.metadata;
-    return new ValidatedEvent(timestamp,
-                              apiHost,
-                              postData,
-                              writeKey,
-                              dataset,
-                              sampleRate,
-                              metadata);
+    return new ValidatedEvent({timestamp,
+                               apiHost,
+                               postData,
+                               writeKey,
+                               dataset,
+                               sampleRate,
+                               metadata});
   }
 
   /**

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0
 // license that can be found in the LICENSE file.
 
+// jshint esversion: 6
 /**
  * @module
  */
@@ -75,7 +76,7 @@ export default class Libhoney extends EventEmitter {
     super();
     this._options = Object.assign({ responseCallback: this._responseCallback.bind(this) }, defaults, opts);
     this._transmission = getAndInitTransmission(this._options.transmission, this._options);
-    this._usable = this._transmission != null;
+    this._usable = this._transmission !== null;
     this._builder = new Builder(this);
 
     this._builder.apiHost = this._options.apiHost;
@@ -86,12 +87,12 @@ export default class Libhoney extends EventEmitter {
     this._responseQueue = [];
   }
 
-  _responseCallback (response) {
+  _responseCallback (responses) {
     let queue = this._responseQueue;
     if (queue.length < this._options.maxResponseQueueSize) {
-      queue.push(response);
+      this._responseQueue = this._responseQueue.concat(responses);
     }
-    this.emit("response", queue);
+    this.emit("response", this._responseQueue);
   }
 
   /**
@@ -230,7 +231,7 @@ export default class Libhoney extends EventEmitter {
    * @private
    */
   validateEvent (event) {
-    if (!this._usable) return;
+    if (!this._usable) return null;
 
     var timestamp = event.timestamp || Date.now();
     if (typeof timestamp === 'string' || typeof timestamp === 'number')
@@ -238,7 +239,7 @@ export default class Libhoney extends EventEmitter {
 
     if (typeof event.data !== 'object' || event.data === null) {
       console.error(".data must be an object");
-      return;
+      return null;
     }
     var postData;
     try {
@@ -246,31 +247,31 @@ export default class Libhoney extends EventEmitter {
     }
     catch (e) {
       console.error("error converting event data to JSON: " + e);
-      return;
+      return null;
     }
 
     var apiHost = event.apiHost;
     if (typeof apiHost !== 'string' || apiHost === "") {
       console.error(".apiHost must be a non-empty string");
-      return;
+      return null;
     }
 
     var writeKey = event.writeKey;
     if (typeof writeKey !== 'string' || writeKey === "") {
       console.error(".writeKey must be a non-empty string");
-      return;
+      return null;
     }
 
     var dataset = event.dataset;
     if (typeof dataset !== 'string' || dataset === "") {
       console.error(".dataset must be a non-empty string");
-      return;
+      return null;
     }
 
     var sampleRate = event.sampleRate;
     if (typeof sampleRate !== 'number') {
       console.error(".sampleRate must be a number");
-      return;
+      return null;
     }
 
     var metadata = event.metadata;

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -40,6 +40,38 @@ const defaults = Object.freeze({
   disabled: false
 });
 
+class ValidatedEvent {
+  constructor(timestamp,
+              apiHost,
+              postData,
+              writeKey,
+              dataset,
+              sampleRate,
+              metadata) {
+    this.timestamp  = timestamp;
+    this.apiHost    = apiHost;
+    this.postData   = postData;
+    this.writeKey   = writeKey;
+    this.dataset    = dataset;
+    this.sampleRate = sampleRate;
+    this.metadata   = metadata;
+  }
+
+  toJSON() {
+    let fields = [];
+    if (this.timestamp) {
+      fields.push(`"time":${JSON.stringify(this.timestamp)}`);
+    }
+    if (this.sampleRate) {
+      fields.push(`"samplerate":${JSON.stringify(this.sampleRate)}`);
+    }
+    if (this.postData) {
+      fields.push(`"data":${this.postData}`);
+    }
+    return `{${fields.join(",")}}`;
+  }
+}
+
 /**
  * libhoney aims to make it as easy as possible to create events and send them on into Honeycomb.
  *
@@ -275,15 +307,13 @@ export default class Libhoney extends EventEmitter {
     }
 
     var metadata = event.metadata;
-    return {
-      timestamp,
-      apiHost,
-      postData,
-      writeKey,
-      dataset,
-      sampleRate,
-      metadata
-    };
+    return new ValidatedEvent(timestamp,
+                              apiHost,
+                              postData,
+                              writeKey,
+                              dataset,
+                              sampleRate,
+                              metadata);
   }
 
   /**

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -64,38 +64,13 @@ class BatchEndpointAggregator {
                              (batch, ev) => batch.events.push(ev));
   }
 
-  encodeEvent (ev) {
-    let encoded = "{";
-    let needComma = false;
-    if (ev.postData) {
-      encoded += `"data":${ev.postData}`;
-      needComma = true;
-    }
-    if (ev.sampleRate) {
-      if (needComma) {
-        encoded += ",";
-      }
-      encoded += `"samplerate":${JSON.stringify(ev.sampleRate)}`;
-      needComma = true;
-    }
-    if (ev.timestamp) {
-      if (needComma) {
-        encoded += ",";
-      }
-      encoded += `"time":${JSON.stringify(ev.timestamp)}`;
-      needComma = true;
-    }
-    encoded += "}";
-    return encoded;
-  }
-
   encodeBatchEvents (events) {
     let numEncoded = 0;
     let encoded = "[" +
           events.map((ev, i) => {
             let evEncoded;
             try {
-              evEncoded = this.encodeEvent(ev);
+              evEncoded = JSON.stringify(ev);
               numEncoded ++;
             } catch (e) {
               ev.encodeError = e;

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -88,7 +88,42 @@ class BatchEndpointAggregator {
 /**
  * @private
  */
-export default class Transmission {
+export class ValidatedEvent {
+  constructor({ timestamp,
+                apiHost,
+                postData,
+                writeKey,
+                dataset,
+                sampleRate,
+                metadata }) {
+    this.timestamp  = timestamp;
+    this.apiHost    = apiHost;
+    this.postData   = postData;
+    this.writeKey   = writeKey;
+    this.dataset    = dataset;
+    this.sampleRate = sampleRate;
+    this.metadata   = metadata;
+  }
+
+  toJSON() {
+    let fields = [];
+    if (this.timestamp) {
+      fields.push(`"time":${JSON.stringify(this.timestamp)}`);
+    }
+    if (this.sampleRate) {
+      fields.push(`"samplerate":${JSON.stringify(this.sampleRate)}`);
+    }
+    if (this.postData) {
+      fields.push(`"data":${this.postData}`);
+    }
+    return `{${fields.join(",")}}`;
+  }
+}
+
+/**
+ * @private
+ */
+export class Transmission {
 
   constructor (options) {
     this._responseCallback = emptyResponseCallback;

--- a/test/transmission_test.js
+++ b/test/transmission_test.js
@@ -1,7 +1,7 @@
 // jshint esversion: 6
 /* global require, describe, it */
 import assert from 'assert';
-import Transmission from '../lib/transmission';
+import { Transmission, ValidatedEvent } from '../lib/transmission';
 
 let superagent = require('superagent');
 let mock = require('superagent-mocker')(superagent);
@@ -25,14 +25,14 @@ describe('transmission', function() {
       }
     });
 
-    transmission.sendEvent({
+    transmission.sendEvent(new ValidatedEvent({
       apiHost: "http://localhost:9999",
       writeKey: "123456789",
       dataset: "test-transmission",
       sampleRate: 1,
       timestamp: new Date(),
       postData: JSON.stringify({ a: 1, b: 2 })
-    });
+    }));
   });
 
   it('should send a batch when batchSizeTrigger is met, not exceeded', function(done) {
@@ -60,14 +60,14 @@ describe('transmission', function() {
     });
 
     for (let i = 0; i < responseExpected; i ++) {
-      transmission.sendEvent({
+      transmission.sendEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
     }
   });
 
@@ -90,14 +90,14 @@ describe('transmission', function() {
       }
     });
 
-    transmission.sendEvent({
+    transmission.sendEvent(new ValidatedEvent({
       apiHost: "http://localhost:9999/",
       writeKey: "123456789",
       dataset: "test-transmission",
       sampleRate: 1,
       timestamp: new Date(),
       postData: JSON.stringify({ a: 1, b: 2 })
-    });
+    }));
   });
      
   it('should eventually send a single event (after the timeout)', function(done) {
@@ -108,14 +108,14 @@ describe('transmission', function() {
       }
     });
 
-    transmission.sendEvent({
+    transmission.sendEvent(new ValidatedEvent({
       apiHost: "http://localhost:9999",
       writeKey: "123456789",
       dataset: "test-transmission",
       sampleRate: 1,
       timestamp: new Date(),
       postData: JSON.stringify({ a: 1, b: 2 })
-    });
+    }));
   });
 
   it('should respect sample rate and accept the event', function(done) {
@@ -127,14 +127,14 @@ describe('transmission', function() {
     });
 
     transmission._randomFn = function() { return 0.09; };
-    transmission.sendEvent({
+    transmission.sendEvent(new ValidatedEvent({
       apiHost: "http://localhost:9999",
       writeKey: "123456789",
       dataset: "test-transmission",
       sampleRate: 10,
       timestamp: new Date(),
       postData: JSON.stringify({ a: 1, b: 2 })
-    });
+    }));
   });
 
   it('should respect sample rate and drop the event', function(done) {
@@ -147,14 +147,14 @@ describe('transmission', function() {
       done();
     };
 
-    transmission.sendEvent({
+    transmission.sendEvent(new ValidatedEvent({
       apiHost: "http://localhost:9999",
       writeKey: "123456789",
       dataset: "test-transmission",
       sampleRate: 10,
       timestamp: new Date(),
       postData: JSON.stringify({ a: 1, b: 2 })
-    });
+    }));
   });
 
   it('should drop events beyond the pendingWorkCapacity', function(done) {
@@ -189,28 +189,28 @@ describe('transmission', function() {
 
     // send the events we expect responses for
     for (let i = 0; i < responseExpected; i ++) {
-      transmission.sendEvent({
+      transmission.sendEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
     }
 
     // send the events we expect to drop.  Since JS is single threaded we can verify that
     // droppedCount behaves the way we want
     for (let i = 0; i < droppedExpected; i ++) {
       eventDropped = false;
-      transmission.sendEvent({
+      transmission.sendEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
       assert.equal(true, eventDropped);
     }
   });
@@ -241,14 +241,14 @@ describe('transmission', function() {
     });
 
     for (let i = 0; i < responseExpected; i ++) {
-      transmission.sendEvent({
+      transmission.sendEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
     }
   });
 
@@ -281,14 +281,14 @@ describe('transmission', function() {
     });
 
     for (let i = 0; i < responseExpected; i ++) {
-      transmission.sendEvent({
+      transmission.sendEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
     }
   });
 
@@ -318,14 +318,14 @@ describe('transmission', function() {
     });
 
     for (let i = 0; i < responseExpected; i ++) {
-      transmission.sendEvent({
+      transmission.sendEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
     }
   });
 
@@ -357,14 +357,14 @@ describe('transmission', function() {
     });
 
     for (let i = 0; i < responseExpected; i ++) {
-      transmission.sendPresampledEvent({
+      transmission.sendPresampledEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 10,
         timestamp: new Date(),
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
     }
   });
 
@@ -394,37 +394,37 @@ describe('transmission', function() {
     let a = {};
     a.a = a;
     for (let i = 0; i < 5; i ++) {
-      transmission.sendPresampledEvent({
+      transmission.sendPresampledEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 10,
         timestamp: new Date(),
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
     }
     {
       // send an event that fails to encode
       let a = {};
       a.a = a;
-      transmission.sendPresampledEvent({
+      transmission.sendPresampledEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 10,
         timestamp: a,
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
     }
     for (let i = 0; i < 5; i ++) {
-      transmission.sendPresampledEvent({
+      transmission.sendPresampledEvent(new ValidatedEvent({
         apiHost: "http://localhost:9999",
         writeKey: "123456789",
         dataset: "test-transmission",
         sampleRate: 10,
         timestamp: new Date(),
         postData: JSON.stringify({ a: 1, b: 2 })
-      });
+      }));
     }
   });
 });


### PR DESCRIPTION
pretty simple pair of changes masked with a lot of additional churn.

Adds a class called `BatchEndpointAggregator` to `transmission.js` that groups events based on apiHost/writekey/datasetname.  It does manual JSON encoding to not double encode event post data (which is already `JSON.stringify`ed before making it to transmission)

The `Transmission#_sendBatch` method is where the other part of the change is.  Once a batch of events is chosen (through timeout or event count triggers), it's aggregated.  Then we create a promise to send each batch endpoint aggregated list of events.

The bulk of the test changes are to deal with the fact that with the batch endpoint supported, we get multiple responses at once.