### PR TITLE
Add support for User-Agent additions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libhoney",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0",
   "description": "Javascript library for sending data to Honeycomb",
   "bugs": "https://github.com/honeycombio/libhoney-js/issues",
   "repository": {

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -37,7 +37,10 @@ const defaults = Object.freeze({
   maxResponseQueueSize: 1000,
 
   // if this is set to true, all sending is disabled.  useful for disabling libhoney when testing
-  disabled: false
+  disabled: false,
+
+  // If this is non-empty, append it to the end of the User-Agent header.
+  userAgentAddition: ""
 });
 
 /**

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -11,7 +11,7 @@
 import superagent from 'superagent';
 import urljoin from 'urljoin';
 
-const userAgent = "libhoney-js/LIBHONEY_JS_VERSION";
+const USER_AGENT = "libhoney-js/LIBHONEY_JS_VERSION";
 
 const _global = (typeof window !== "undefined" ? window :
                  typeof global !== "undefined" ? global : undefined);
@@ -151,6 +151,8 @@ export class Transmission {
       this._pendingWorkCapacity = options.pendingWorkCapacity;
     }
 
+    this._userAgentAddition = options.userAgentAddition || "";
+
     // Included for testing; to stub out randomness and verify that an event
     // was dropped.
     this._randomFn = Math.random;
@@ -201,7 +203,7 @@ export class Transmission {
 
     let batchAgg = new BatchEndpointAggregator(batch);
 
-    let finishBatch = () => {
+    const finishBatch = () => {
       this._batchCount--;
 
       let queueLength = this._eventQueue.length;
@@ -212,6 +214,11 @@ export class Transmission {
           this._ensureSendTimeout();
         }
       }
+    };
+
+    const finishBatchWithError = (e) => {
+      console.error(e);
+      finishBatch();
     };
 
     let batches = Object.keys(batchAgg.batches).map((k) => batchAgg.batches[k]);
@@ -230,6 +237,12 @@ export class Transmission {
           })));
           resolve();
           return;
+        }
+
+        let userAgent = USER_AGENT;
+        let trimmedAddition = this._userAgentAddition.trim();
+        if (trimmedAddition) {
+          userAgent = `${USER_AGENT} ${trimmedAddition}`;
         }
 
         var start = Date.now();
@@ -275,7 +288,7 @@ export class Transmission {
           });
       });
     }).then(finishBatch)
-      .catch(finishBatch);
+      .catch(finishBatchWithError);
   }
 
   _shouldSendEvent (ev) {

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -216,11 +216,6 @@ export class Transmission {
       }
     };
 
-    const finishBatchWithError = (e) => {
-      console.error(e);
-      finishBatch();
-    };
-
     let batches = Object.keys(batchAgg.batches).map((k) => batchAgg.batches[k]);
     eachPromise(batches, (batch) => {
       var url = urljoin(batch.apiHost, "/1/batch", batch.dataset);
@@ -288,7 +283,7 @@ export class Transmission {
           });
       });
     }).then(finishBatch)
-      .catch(finishBatchWithError);
+      .catch(finishBatch);
   }
 
   _shouldSendEvent (ev) {

--- a/test/transmission_test.js
+++ b/test/transmission_test.js
@@ -427,4 +427,39 @@ describe('transmission', function() {
       }));
     }
   });
+
+  it('should allow user-agent additions', function(done) {
+    var responseCount = 0;
+    var userAgentReceived = "";
+
+    var UAs = [
+      { addition: "", probe: (ua) => indexOf("libhoney") === 0 && indexOf("addition") === -1 },
+      { addition: "user-agent addition", probe: (ua) => indexOf("libhoney") === 0 && indexOf("addition") !== -1 },
+    ];
+
+    mock.post('http://localhost:9999/1/batch/test-transmission', function(req) {
+      userAgentReceieved = req.headers["User-Agent"];
+      return {};
+    });
+
+    var transmission = new Transmission({
+      responseCallback (queue) {
+        if (queue.length > 0) {
+          if (userAgentReceived.indexOf("addition" !== -1)) {
+            done();
+          }
+        }
+      },
+      userAgentAddition: "user-agent addition here"
+    });
+
+    transmission.sendPresampledEvent(new ValidatedEvent({
+      apiHost: "http://localhost:9999",
+      writeKey: "123456789",
+      dataset: "test-transmission",
+      sampleRate: 10,
+      timestamp: new Date(),
+      postData: JSON.stringify({ a: 1, b: 2 })
+    }));
+  });
 });


### PR DESCRIPTION
Follow libhoney-go's lead here and add a special configuration option that lets the user put additional info in the User-Agent string.

For the go sdk we use this to tag integrations, and the same will hold true here.

Also, it's about time we flipped out of beta so people can start getting updates via semver as opposed to explicitly updating to a new beta.