### PR TITLE
don't stringify objects in builder.addField

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -88,14 +88,7 @@ export default class Builder {
    *   builder.addField("component", "web");
    */
   addField (name, val) {
-    if (typeof val === "object") {
-      // JS reports typeof == object for a lot of things that we don't need additional processing to handle
-      if (val === null || val instanceof Boolean || val instanceof Number || val instanceof Date || val instanceof String) {
-        // these are fine
-      } else {
-        val = JSON.stringify(val);
-      }
-    } else if (val == undefined) {
+    if (val == undefined) {
       val = null;
     }
     this._fields[name] = val;

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -33,6 +33,23 @@ describe('libhoney builder', function() {
     assert.equal(5, ev.data.a);
   });
 
+  it("doesn't stringify object values", function() {
+    var honey = new libhoney({
+      apiHost: "http://foo/bar",
+      writeKey: "12345",
+      dataset: "testing",
+      transmission: MockTransmission
+    });
+
+    var postData = { c: { a: 1 } };
+
+    var builder = honey.newBuilder();
+
+    builder.sendNow({ c: { a: 1 } });
+
+    assert.equal(_transmissionSendEventArg.postData, JSON.stringify(postData));
+  });
+
   it("includes snapshot of global fields/dyn_fields", function() {
     var honey = new libhoney({
       apiHost: "http://foo/bar",

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -41,11 +41,11 @@ describe('libhoney builder', function() {
       transmission: MockTransmission
     });
 
-    var postData = { c: { a: 1 } };
+    var postData = { a: { b: 1 }, c: { d: 2 } };
 
-    var builder = honey.newBuilder();
+    var builder = honey.newBuilder({a: { b : 1 }});
 
-    builder.sendNow({ c: { a: 1 } });
+    builder.sendNow({ c: { d: 2 } });
 
     assert.equal(_transmissionSendEventArg.postData, JSON.stringify(postData));
   });

--- a/test/event_test.js
+++ b/test/event_test.js
@@ -38,6 +38,16 @@ describe('libhoney events', function() {
     assert.equal(5, ev.data.hello);
   });
 
+  it("doesn't stringify object values", function() {
+    var postData = { c: { a: 1 } };
+
+    var ev = hny.newEvent();
+
+    ev.add({ c: { a: 1 } });
+
+    assert.equal(JSON.stringify(ev.data), JSON.stringify({ c: { a: 1 } }));
+  });
+
   it("converts all values to primitive types in .add/.addField", function() {
     var b = hny.newBuilder();
     var ev;


### PR DESCRIPTION
`event.addField`/`.add` already work this way, but `builder.addField` does it differently because.. some reason.

Add tests for both events and builders.