### PR TITLE
updating readme to include correct npm installation and adding yarn

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ Libhoney-js contributors:
 Ben Hartshorne
 Chris Toshok
 Christine Yen
+Josh Jarmain

--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@ A node module for interacting with [Honeycomb](https://honeycomb.io). (For more 
 
 ## Installation
 
+### npm
 ```
 npm install libhoney --save
+```
+### yarn
+```
+yarn add libhoney
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A node module for interacting with [Honeycomb](https://honeycomb.io). (For more 
 ## Installation
 
 ```
-npm install libhoney --save-dev
+npm install libhoney --save
 ```
 
 ## Documentation


### PR DESCRIPTION
I found these two issues with the ReadMe while I was using libhoney, the documentation doesn't seem to have its own repo so they will so need to be updated to be at parity. 

1) Updated npm installation to have --save instead of --save-dev 
2) Add yarn install to installation