### PR TITLE
Upgrade superagent to remove vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "superagent-mocker": "^0.5.2"
   },
   "dependencies": {
-    "superagent": "^2.3.0",
+    "superagent": "^3.7.0",
     "urljoin": "^0.1.5"
   }
 }


### PR DESCRIPTION
Hi team Honeycomb 👋 

We ([Snyk](https://snyk.io)) just started checking out Honeycomb, and noticed that the version of superagent used in this lib has a [low-severity vulnerability](https://snyk.io/vuln/npm:superagent:20170807).

This small PR updates superagent to a non-vulnerable version. From the [superagent release notes](https://github.com/visionmedia/superagent/releases/tag/v3.0.0) it looks like biggest potential impact of jumping from 2.x to 3.x is the Node 4+ requirement. I couldn't tell from this repo whether that is going to be an issue for you, so figured I'd raise the PR in any case 😄 