### PR TITLE
Rename example package name to be unique

### DIFF
--- a/examples/express-dynamic-fields/package.json
+++ b/examples/express-dynamic-fields/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "simple-express-test",
+  "name": "express-dynamic-fields-test",
   "version": "1.0.0",
   "description": "",
   "main": "app.js",


### PR DESCRIPTION
Was previously conflicting with another package within the examples/
directory and issuing a warning when running the test suite.