### PR TITLE
Add more linting rules to improve readability

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
     "comma-dangle": "error",
     "quotes": "error",
     "camelcase": "error",
-    "sort-imports": "error"
+    "sort-imports": "error",
+    "no-param-reassign": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
     "semi": 2,
     "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "prefer-arrow-callback": "error",
-    "no-var": "error"
+    "no-var": "error",
+    "eqeqeq": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "prefer-arrow-callback": "error",
     "no-var": "error",
-    "eqeqeq": "error"
+    "eqeqeq": "error",
+    "comma-dangle": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "no-var": "error",
     "eqeqeq": "error",
     "comma-dangle": "error",
-    "quotes": "error"
+    "quotes": "error",
+    "camelcase": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "eqeqeq": "error",
     "comma-dangle": "error",
     "quotes": "error",
-    "camelcase": "error"
+    "camelcase": "error",
+    "sort-imports": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
   "rules": {
     "no-console": "off",
     "semi": 2,
-    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "prefer-arrow-callback": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "prefer-arrow-callback": "error",
     "no-var": "error",
     "eqeqeq": "error",
-    "comma-dangle": "error"
+    "comma-dangle": "error",
+    "quotes": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "no-console": "off",
     "semi": 2,
     "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-    "prefer-arrow-callback": "error"
+    "prefer-arrow-callback": "error",
+    "no-var": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
     "quotes": "error",
     "camelcase": "error",
     "sort-imports": "error",
-    "no-param-reassign": "error"
+    "no-param-reassign": "error",
+    "no-shadow": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/core": "^7.4.0",
     "@babel/preset-env": "^7.4.2",
     "babel-jest": "^24.5.0",
-    "eslint": "^5.2.0",
+    "eslint": "^5.15.3",
     "husky": "^0.14.3",
     "jest": "^24.5.0",
     "jest-in-case": "^1.0.2",

--- a/src/__tests__/builder_test.js
+++ b/src/__tests__/builder_test.js
@@ -2,10 +2,10 @@
 import libhoney from "../libhoney";
 
 describe("libhoney builder", () => {
-  var hny = new libhoney();
+  let hny = new libhoney();
 
   it("takes fields and dynamic fields in ctor", () => {
-    var b = hny.newBuilder(
+    let b = hny.newBuilder(
       { a: 5 },
       {
         b: function() {
@@ -21,15 +21,15 @@ describe("libhoney builder", () => {
   });
 
   it("accepts dict-like arguments to .add()", () => {
-    var b;
-    var ev;
+    let b;
+    let ev;
 
     b = hny.newBuilder();
     b.add({ a: 5 });
     ev = b.newEvent();
     expect(ev.data.a).toEqual(5);
 
-    var map = new Map();
+    let map = new Map();
     map.set("a", 5);
     b = hny.newBuilder();
     b.add(map);
@@ -38,17 +38,17 @@ describe("libhoney builder", () => {
   });
 
   it("doesn't stringify object values", () => {
-    var honey = new libhoney({
+    let honey = new libhoney({
       apiHost: "http://foo/bar",
       writeKey: "12345",
       dataset: "testing",
       transmission: "mock"
     });
-    var transmission = honey.transmission;
+    let transmission = honey.transmission;
 
-    var postData = { a: { b: 1 }, c: { d: 2 } };
+    let postData = { a: { b: 1 }, c: { d: 2 } };
 
-    var builder = honey.newBuilder({ a: { b: 1 } });
+    let builder = honey.newBuilder({ a: { b: 1 } });
 
     builder.sendNow({ c: { d: 2 } });
 
@@ -57,17 +57,17 @@ describe("libhoney builder", () => {
   });
 
   it("includes snapshot of global fields/dyn_fields", () => {
-    var honey = new libhoney({
+    let honey = new libhoney({
       apiHost: "http://foo/bar",
       writeKey: "12345",
       dataset: "testing",
       transmission: "mock"
     });
-    var transmission = honey.transmission;
+    let transmission = honey.transmission;
 
-    var postData = { b: 2, c: 3 };
+    let postData = { b: 2, c: 3 };
 
-    var builder = honey.newBuilder({ b: 2 });
+    let builder = honey.newBuilder({ b: 2 });
 
     // add a global field *after* creating the builder.  it shouldn't show up in the post data
     honey.addField("a", 1);

--- a/src/__tests__/builder_test.js
+++ b/src/__tests__/builder_test.js
@@ -17,7 +17,7 @@ describe("libhoney builder", () => {
     expect(b._fields.b).toEqual(undefined);
     b = hny.newBuilder();
     expect(Object.getOwnPropertyNames(b._fields)).toHaveLength(0);
-    expect(Object.getOwnPropertyNames(b._dyn_fields)).toHaveLength(0);
+    expect(Object.getOwnPropertyNames(b._dynFields)).toHaveLength(0);
   });
 
   it("accepts dict-like arguments to .add()", () => {
@@ -56,7 +56,7 @@ describe("libhoney builder", () => {
     expect(transmission.events[0].postData).toEqual(JSON.stringify(postData));
   });
 
-  it("includes snapshot of global fields/dyn_fields", () => {
+  it("includes snapshot of global fields/dynFields", () => {
     let honey = new libhoney({
       apiHost: "http://foo/bar",
       writeKey: "12345",

--- a/src/__tests__/builder_test.js
+++ b/src/__tests__/builder_test.js
@@ -1,10 +1,10 @@
 /* eslint-env node, jest */
 import libhoney from "../libhoney";
 
-describe("libhoney builder", function() {
+describe("libhoney builder", () => {
   var hny = new libhoney();
 
-  it("takes fields and dynamic fields in ctor", function() {
+  it("takes fields and dynamic fields in ctor", () => {
     var b = hny.newBuilder(
       { a: 5 },
       {
@@ -20,7 +20,7 @@ describe("libhoney builder", function() {
     expect(Object.getOwnPropertyNames(b._dyn_fields)).toHaveLength(0);
   });
 
-  it("accepts dict-like arguments to .add()", function() {
+  it("accepts dict-like arguments to .add()", () => {
     var b;
     var ev;
 
@@ -37,7 +37,7 @@ describe("libhoney builder", function() {
     expect(ev.data.a).toEqual(5);
   });
 
-  it("doesn't stringify object values", function() {
+  it("doesn't stringify object values", () => {
     var honey = new libhoney({
       apiHost: "http://foo/bar",
       writeKey: "12345",
@@ -56,7 +56,7 @@ describe("libhoney builder", function() {
     expect(transmission.events[0].postData).toEqual(JSON.stringify(postData));
   });
 
-  it("includes snapshot of global fields/dyn_fields", function() {
+  it("includes snapshot of global fields/dyn_fields", () => {
     var honey = new libhoney({
       apiHost: "http://foo/bar",
       writeKey: "12345",

--- a/src/__tests__/event_test.js
+++ b/src/__tests__/event_test.js
@@ -2,10 +2,10 @@
 import libhoney from "../libhoney";
 
 describe("libhoney events", () => {
-  var hny = new libhoney();
+  let hny = new libhoney();
 
   it("inherit fields and dyn_fields from builder", () => {
-    var b = hny.newBuilder(
+    let b = hny.newBuilder(
       { a: 5 },
       {
         b: function() {
@@ -14,30 +14,30 @@ describe("libhoney events", () => {
       }
     );
 
-    var ev = b.newEvent();
+    let ev = b.newEvent();
     expect(ev.data.a).toEqual(5);
     expect(ev.data.b).toEqual(3);
   });
 
   it("accepts dict-like arguments to .add()", () => {
-    var b = hny.newBuilder();
-    var ev = b.newEvent();
+    let b = hny.newBuilder();
+    let ev = b.newEvent();
 
     ev.add({ a: 5 });
     expect(ev.data.a).toEqual(5);
 
-    var ev2 = b.newEvent();
-    var map = new Map();
+    let ev2 = b.newEvent();
+    let map = new Map();
     map.set("a", 5);
     ev2.add(map);
     expect(ev2.data.a).toEqual(5);
   });
 
   it("it toString()'s keys from Maps in .add()", () => {
-    var b = hny.newBuilder();
-    var ev = b.newEvent();
+    let b = hny.newBuilder();
+    let ev = b.newEvent();
 
-    var map = new Map();
+    let map = new Map();
     map.set(
       {
         toString: function() {
@@ -52,9 +52,9 @@ describe("libhoney events", () => {
   });
 
   it("doesn't stringify object values", () => {
-    var postData = { c: { a: 1 } };
+    let postData = { c: { a: 1 } };
 
-    var ev = hny.newEvent();
+    let ev = hny.newEvent();
 
     ev.add(postData);
 
@@ -62,9 +62,9 @@ describe("libhoney events", () => {
   });
 
   it("converts all values to primitive types in .add/.addField", () => {
-    var b = hny.newBuilder();
-    var ev;
-    var map;
+    let b = hny.newBuilder();
+    let ev;
+    let map;
 
     ev = b.newEvent();
     map = new Map();
@@ -86,7 +86,7 @@ describe("libhoney events", () => {
     map.set("boolean", true);
 
     // Date does not convert
-    var d = new Date(1, 2, 3, 4, 5, 6, 7);
+    let d = new Date(1, 2, 3, 4, 5, 6, 7);
     map.set("Date", d);
 
     // Null/undefined both end up being null in the output

--- a/src/__tests__/event_test.js
+++ b/src/__tests__/event_test.js
@@ -1,10 +1,10 @@
 /* eslint-env node, jest */
 import libhoney from "../libhoney";
 
-describe("libhoney events", function() {
+describe("libhoney events", () => {
   var hny = new libhoney();
 
-  it("inherit fields and dyn_fields from builder", function() {
+  it("inherit fields and dyn_fields from builder", () => {
     var b = hny.newBuilder(
       { a: 5 },
       {
@@ -19,7 +19,7 @@ describe("libhoney events", function() {
     expect(ev.data.b).toEqual(3);
   });
 
-  it("accepts dict-like arguments to .add()", function() {
+  it("accepts dict-like arguments to .add()", () => {
     var b = hny.newBuilder();
     var ev = b.newEvent();
 
@@ -33,7 +33,7 @@ describe("libhoney events", function() {
     expect(ev2.data.a).toEqual(5);
   });
 
-  it("it toString()'s keys from Maps in .add()", function() {
+  it("it toString()'s keys from Maps in .add()", () => {
     var b = hny.newBuilder();
     var ev = b.newEvent();
 
@@ -51,7 +51,7 @@ describe("libhoney events", function() {
     expect(ev.data.hello).toEqual(5);
   });
 
-  it("doesn't stringify object values", function() {
+  it("doesn't stringify object values", () => {
     var postData = { c: { a: 1 } };
 
     var ev = hny.newEvent();
@@ -61,7 +61,7 @@ describe("libhoney events", function() {
     expect(JSON.stringify(ev.data)).toEqual(JSON.stringify(postData));
   });
 
-  it("converts all values to primitive types in .add/.addField", function() {
+  it("converts all values to primitive types in .add/.addField", () => {
     var b = hny.newBuilder();
     var ev;
     var map;

--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -7,7 +7,7 @@ let mock = require("superagent-mocker")(superagent);
 describe("libhoney", () => {
   describe("constructor options", () => {
     it("should be communicated to transmission constructor", () => {
-      var options = { a: 1, b: 2, c: 3, d: 4, transmission: "mock" };
+      let options = { a: 1, b: 2, c: 3, d: 4, transmission: "mock" };
 
       let honey = new libhoney(options);
 
@@ -22,14 +22,14 @@ describe("libhoney", () => {
 
   describe("event properties", () => {
     it("should ultimately fallback to hardcoded defaults", () => {
-      var honey = new libhoney({
+      let honey = new libhoney({
         // these two properties are required
         writeKey: "12345",
         dataset: "testing",
         transmission: "mock"
       });
       let transmission = honey.transmission;
-      var postData = { a: 1, b: 2 };
+      let postData = { a: 1, b: 2 };
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(1);
@@ -45,14 +45,14 @@ describe("libhoney", () => {
     });
 
     it("should come from libhoney options if not specified in event", () => {
-      var honey = new libhoney({
+      let honey = new libhoney({
         apiHost: "http://foo/bar",
         writeKey: "12345",
         dataset: "testing",
         transmission: "mock"
       });
       let transmission = honey.transmission;
-      var postData = { a: 1, b: 2 };
+      let postData = { a: 1, b: 2 };
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(1);
@@ -69,9 +69,9 @@ describe("libhoney", () => {
         return {};
       });
 
-      var queueSize = 50;
-      var queueFullCount = 0;
-      var honey = new libhoney({
+      let queueSize = 50;
+      let queueFullCount = 0;
+      let honey = new libhoney({
         apiHost: "http://localhost:9999",
         writeKey: "12345",
         dataset: "testResponseQueue",
@@ -94,8 +94,8 @@ describe("libhoney", () => {
         }
       });
 
-      for (var i = 0; i < queueSize + 1; i++) {
-        var ev = honey.newEvent();
+      for (let i = 0; i < queueSize + 1; i++) {
+        let ev = honey.newEvent();
         ev.add({ a: 1, b: 2 });
         ev.addMetadata(i);
         ev.send();
@@ -105,14 +105,14 @@ describe("libhoney", () => {
 
   describe("disabled = true", () => {
     it("should not hit transmission", () => {
-      var honey = new libhoney({
+      let honey = new libhoney({
         // these two properties are required
         writeKey: "12345",
         dataset: "testing",
         transmission: "mock",
         disabled: true
       });
-      var transmission = honey.transmission;
+      let transmission = honey.transmission;
 
       expect(transmission).toBe(null);
     });

--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -4,9 +4,9 @@ import libhoney from "../libhoney";
 let superagent = require("superagent");
 let mock = require("superagent-mocker")(superagent);
 
-describe("libhoney", function() {
-  describe("constructor options", function() {
-    it("should be communicated to transmission constructor", function() {
+describe("libhoney", () => {
+  describe("constructor options", () => {
+    it("should be communicated to transmission constructor", () => {
       var options = { a: 1, b: 2, c: 3, d: 4, transmission: "mock" };
 
       let honey = new libhoney(options);
@@ -20,8 +20,8 @@ describe("libhoney", function() {
     });
   });
 
-  describe("event properties", function() {
-    it("should ultimately fallback to hardcoded defaults", function() {
+  describe("event properties", () => {
+    it("should ultimately fallback to hardcoded defaults", () => {
       var honey = new libhoney({
         // these two properties are required
         writeKey: "12345",
@@ -44,7 +44,7 @@ describe("libhoney", function() {
       expect(transmission.events[0].postData).toEqual(JSON.stringify(postData));
     });
 
-    it("should come from libhoney options if not specified in event", function() {
+    it("should come from libhoney options if not specified in event", () => {
       var honey = new libhoney({
         apiHost: "http://foo/bar",
         writeKey: "12345",
@@ -63,11 +63,9 @@ describe("libhoney", function() {
     });
   });
 
-  describe("response queue", function() {
-    it("should enqueue a maximum of maxResponseQueueSize, dropping new responses (not old)", function(done) {
-      mock.post("http://localhost:9999/1/events/testResponseQueue", function(
-        _req
-      ) {
+  describe("response queue", () => {
+    it("should enqueue a maximum of maxResponseQueueSize, dropping new responses (not old)", done => {
+      mock.post("http://localhost:9999/1/events/testResponseQueue", _req => {
         return {};
       });
 
@@ -105,8 +103,8 @@ describe("libhoney", function() {
     });
   });
 
-  describe("disabled = true", function() {
-    it("should not hit transmission", function() {
+  describe("disabled = true", () => {
+    it("should not hit transmission", () => {
       var honey = new libhoney({
         // these two properties are required
         writeKey: "12345",

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -5,9 +5,9 @@ import { Transmission, ValidatedEvent } from "../transmission";
 let superagent = require("superagent");
 let mock = require("superagent-mocker")(superagent);
 
-describe("base transmission", function() {
-  it("will hit a proxy", function(done) {
-    let server = net.createServer(function(socket) {
+describe("base transmission", () => {
+  it("will hit a proxy", done => {
+    let server = net.createServer(socket => {
       socket.end();
       server.unref();
       done();
@@ -33,10 +33,8 @@ describe("base transmission", function() {
     );
   });
 
-  it("should handle batchSizeTrigger of 0", function(done) {
-    mock.post("http://localhost:9999/1/events/test-transmission", function(
-      req
-    ) {
+  it("should handle batchSizeTrigger of 0", done => {
+    mock.post("http://localhost:9999/1/events/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
@@ -62,11 +60,11 @@ describe("base transmission", function() {
     );
   });
 
-  it("should send a batch when batchSizeTrigger is met, not exceeded", function(done) {
+  it("should send a batch when batchSizeTrigger is met, not exceeded", done => {
     var responseCount = 0;
     var batchSize = 5;
 
-    mock.post("http://localhost:9999/1/batch/test-transmission", function(req) {
+    mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
@@ -101,9 +99,9 @@ describe("base transmission", function() {
     }
   });
 
-  it("should handle apiHosts with trailing slashes", function(done) {
+  it("should handle apiHosts with trailing slashes", done => {
     let endpointHit = false;
-    mock.post("http://localhost:9999/1/batch/test-transmission", function(req) {
+    mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       endpointHit = true;
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
@@ -130,7 +128,7 @@ describe("base transmission", function() {
     );
   });
 
-  it("should eventually send a single event (after the timeout)", function(done) {
+  it("should eventually send a single event (after the timeout)", done => {
     var transmission = new Transmission({
       batchTimeTrigger: 10,
       responseCallback: function(_resp) {
@@ -150,7 +148,7 @@ describe("base transmission", function() {
     );
   });
 
-  it("should respect sample rate and accept the event", function(done) {
+  it("should respect sample rate and accept the event", done => {
     var transmission = new Transmission({
       batchTimeTrigger: 10,
       responseCallback: function(_resp) {
@@ -173,7 +171,7 @@ describe("base transmission", function() {
     );
   });
 
-  it("should respect sample rate and drop the event", function(done) {
+  it("should respect sample rate and drop the event", done => {
     var transmission = new Transmission({ batchTimeTrigger: 10 });
 
     transmission._randomFn = function() {
@@ -195,13 +193,13 @@ describe("base transmission", function() {
     );
   });
 
-  it("should drop events beyond the pendingWorkCapacity", function(done) {
+  it("should drop events beyond the pendingWorkCapacity", done => {
     var eventDropped;
     var droppedExpected = 5;
     var responseCount = 0;
     var responseExpected = 5;
 
-    mock.post("http://localhost:9999/1/batch/test-transmission", function(req) {
+    mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
@@ -255,11 +253,11 @@ describe("base transmission", function() {
     }
   });
 
-  it("should send the right number events even if it requires multiple concurrent batches", function(done) {
+  it("should send the right number events even if it requires multiple concurrent batches", done => {
     var responseCount = 0;
     var responseExpected = 10;
 
-    mock.post("http://localhost:9999/1/batch/test-transmission", function(req) {
+    mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
@@ -292,13 +290,11 @@ describe("base transmission", function() {
     }
   });
 
-  it("should send the right number of events even if they all fail", function(done) {
+  it("should send the right number of events even if they all fail", done => {
     var responseCount = 0;
     var responseExpected = 10;
 
-    mock.post("http://localhost:9999/1/batch/test-transmission", function(
-      _req
-    ) {
+    mock.post("http://localhost:9999/1/batch/test-transmission", _req => {
       return { status: 404 };
     });
 
@@ -334,11 +330,11 @@ describe("base transmission", function() {
     }
   });
 
-  it("should send the right number of events even it requires more batches than maxConcurrentBatch", function(done) {
+  it("should send the right number of events even it requires more batches than maxConcurrentBatch", done => {
     var responseCount = 0;
     var responseExpected = 50;
     var batchSize = 2;
-    mock.post("http://localhost:9999/1/batch/test-transmission", function(req) {
+    mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
@@ -371,10 +367,10 @@ describe("base transmission", function() {
     }
   });
 
-  it("should send 100% of presampled events", function(done) {
+  it("should send 100% of presampled events", done => {
     var responseCount = 0;
     var responseExpected = 10;
-    mock.post("http://localhost:9999/1/batch/test-transmission", function(req) {
+    mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
@@ -410,10 +406,10 @@ describe("base transmission", function() {
     }
   });
 
-  it("should deal with encoding errors", function(done) {
+  it("should deal with encoding errors", done => {
     var responseCount = 0;
     var responseExpected = 11;
-    mock.post("http://localhost:9999/1/batch/test-transmission", function(req) {
+    mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
@@ -475,7 +471,7 @@ describe("base transmission", function() {
     }
   });
 
-  it("should allow user-agent additions", function(done) {
+  it("should allow user-agent additions", done => {
     var responseCount = 0;
     var responseExpected = 2;
 
@@ -498,9 +494,7 @@ describe("base transmission", function() {
 
     // set up our endpoints
     userAgents.forEach(userAgent =>
-      mock.post(`http://localhost:9999/1/batch/${userAgent.dataset}`, function(
-        req
-      ) {
+      mock.post(`http://localhost:9999/1/batch/${userAgent.dataset}`, req => {
         if (!userAgent.probe(req.headers["user-agent"])) {
           done(new Error("unexpected user-agent addition"));
         }

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -444,15 +444,15 @@ describe("base transmission", () => {
     }
     {
       // send an event that fails to encode
-      let a = {};
-      a.a = a;
+      let b = {};
+      b.b = b;
       transmission.sendPresampledEvent(
         new ValidatedEvent({
           apiHost: "http://localhost:9999",
           writeKey: "123456789",
           dataset: "test-transmission",
           sampleRate: 10,
-          timestamp: a,
+          timestamp: b,
           postData: JSON.stringify({ a: 1, b: 2 })
         })
       );

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -79,7 +79,7 @@ describe("base transmission", () => {
         return responseCount === batchSize
           ? done()
           : done(
-              `The events dispatched over transmission does not align with batch size when the same number of ` +
+              "The events dispatched over transmission does not align with batch size when the same number of " +
                 `events were enqueued as the batchSizeTrigger. Expected ${batchSize}, got ${responseCount}.`
             );
       }

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -76,7 +76,7 @@ describe("base transmission", () => {
       responseCallback(queue) {
         responseCount += queue.length;
         queue.splice(0, queue.length);
-        return responseCount == batchSize
+        return responseCount === batchSize
           ? done()
           : done(
               `The events dispatched over transmission does not align with batch size when the same number of ` +
@@ -211,7 +211,7 @@ describe("base transmission", () => {
       responseCallback(queue) {
         responseCount += queue.length;
         queue.splice(0, queue.length);
-        if (responseCount == responseExpected) {
+        if (responseCount === responseExpected) {
           done();
         }
       }
@@ -270,7 +270,7 @@ describe("base transmission", () => {
       responseCallback(queue) {
         responseCount += queue.length;
         queue.splice(0, queue.length);
-        if (responseCount == responseExpected) {
+        if (responseCount === responseExpected) {
           done();
         }
       }
@@ -309,7 +309,7 @@ describe("base transmission", () => {
           expect(error.status).toEqual(404);
           expect(status_code).toEqual(404);
           responseCount++;
-          if (responseCount == responseExpected) {
+          if (responseCount === responseExpected) {
             done();
           }
         });
@@ -347,7 +347,7 @@ describe("base transmission", () => {
       responseCallback(queue) {
         responseCount += queue.length;
         queue.splice(0, queue.length);
-        if (responseCount == responseExpected) {
+        if (responseCount === responseExpected) {
           done();
         }
       }
@@ -385,7 +385,7 @@ describe("base transmission", () => {
             return;
           }
           responseCount++;
-          if (responseCount == responseExpected) {
+          if (responseCount === responseExpected) {
             done();
           }
         });

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -15,7 +15,7 @@ describe("base transmission", () => {
 
     server.listen(9998, "127.0.0.1");
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       proxy: "http://127.0.0.1:9998",
       batchTimeTrigger: 10000, // larger than the mocha timeout
       batchSizeTrigger: 0
@@ -40,7 +40,7 @@ describe("base transmission", () => {
       return { text: JSON.stringify(resp) };
     });
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       batchTimeTrigger: 10000, // larger than the mocha timeout
       batchSizeTrigger: 0,
       responseCallback() {
@@ -61,8 +61,8 @@ describe("base transmission", () => {
   });
 
   it("should send a batch when batchSizeTrigger is met, not exceeded", done => {
-    var responseCount = 0;
-    var batchSize = 5;
+    let responseCount = 0;
+    let batchSize = 5;
 
     mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
@@ -70,7 +70,7 @@ describe("base transmission", () => {
       return { text: JSON.stringify(resp) };
     });
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       batchTimeTrigger: 10000, // larger than the mocha timeout
       batchSizeTrigger: 5,
       responseCallback(queue) {
@@ -108,7 +108,7 @@ describe("base transmission", () => {
       return { text: JSON.stringify(resp) };
     });
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       batchTimeTrigger: 0,
       responseCallback: function(_resp) {
         expect(endpointHit).toBe(true);
@@ -129,7 +129,7 @@ describe("base transmission", () => {
   });
 
   it("should eventually send a single event (after the timeout)", done => {
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       batchTimeTrigger: 10,
       responseCallback: function(_resp) {
         done();
@@ -149,7 +149,7 @@ describe("base transmission", () => {
   });
 
   it("should respect sample rate and accept the event", done => {
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       batchTimeTrigger: 10,
       responseCallback: function(_resp) {
         done();
@@ -172,7 +172,7 @@ describe("base transmission", () => {
   });
 
   it("should respect sample rate and drop the event", done => {
-    var transmission = new Transmission({ batchTimeTrigger: 10 });
+    let transmission = new Transmission({ batchTimeTrigger: 10 });
 
     transmission._randomFn = function() {
       return 0.11;
@@ -194,10 +194,10 @@ describe("base transmission", () => {
   });
 
   it("should drop events beyond the pendingWorkCapacity", done => {
-    var eventDropped;
-    var droppedExpected = 5;
-    var responseCount = 0;
-    var responseExpected = 5;
+    let eventDropped;
+    let droppedExpected = 5;
+    let responseCount = 0;
+    let responseExpected = 5;
 
     mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
@@ -205,7 +205,7 @@ describe("base transmission", () => {
       return { text: JSON.stringify(resp) };
     });
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       batchTimeTrigger: 50,
       pendingWorkCapacity: responseExpected,
       responseCallback(queue) {
@@ -254,8 +254,8 @@ describe("base transmission", () => {
   });
 
   it("should send the right number events even if it requires multiple concurrent batches", done => {
-    var responseCount = 0;
-    var responseExpected = 10;
+    let responseCount = 0;
+    let responseExpected = 10;
 
     mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
@@ -263,7 +263,7 @@ describe("base transmission", () => {
       return { text: JSON.stringify(resp) };
     });
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       batchTimeTrigger: 50,
       batchSizeTrigger: 5,
       pendingWorkCapacity: responseExpected,
@@ -291,14 +291,14 @@ describe("base transmission", () => {
   });
 
   it("should send the right number of events even if they all fail", done => {
-    var responseCount = 0;
-    var responseExpected = 10;
+    let responseCount = 0;
+    let responseExpected = 10;
 
     mock.post("http://localhost:9999/1/batch/test-transmission", _req => {
       return { status: 404 };
     });
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       batchTimeTrigger: 50,
       batchSizeTrigger: 5,
       maxConcurrentBatches: 1,
@@ -331,16 +331,16 @@ describe("base transmission", () => {
   });
 
   it("should send the right number of events even it requires more batches than maxConcurrentBatch", done => {
-    var responseCount = 0;
-    var responseExpected = 50;
-    var batchSize = 2;
+    let responseCount = 0;
+    let responseExpected = 50;
+    let batchSize = 2;
     mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
     });
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       batchTimeTrigger: 50,
       batchSizeTrigger: batchSize,
       pendingWorkCapacity: responseExpected,
@@ -368,15 +368,15 @@ describe("base transmission", () => {
   });
 
   it("should send 100% of presampled events", done => {
-    var responseCount = 0;
-    var responseExpected = 10;
+    let responseCount = 0;
+    let responseExpected = 10;
     mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
     });
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       responseCallback(queue) {
         let responses = queue.splice(0, queue.length);
         responses.forEach(resp => {
@@ -407,15 +407,15 @@ describe("base transmission", () => {
   });
 
   it("should deal with encoding errors", done => {
-    var responseCount = 0;
-    var responseExpected = 11;
+    let responseCount = 0;
+    let responseExpected = 11;
     mock.post("http://localhost:9999/1/batch/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);
       let resp = reqEvents.map(() => ({ status: 202 }));
       return { text: JSON.stringify(resp) };
     });
 
-    var transmission = new Transmission({
+    let transmission = new Transmission({
       responseCallback(queue) {
         responseCount = queue.length;
         return responseCount === responseExpected
@@ -472,10 +472,10 @@ describe("base transmission", () => {
   });
 
   it("should allow user-agent additions", done => {
-    var responseCount = 0;
-    var responseExpected = 2;
+    let responseCount = 0;
+    let responseExpected = 2;
 
-    var userAgents = [
+    let userAgents = [
       {
         dataset: "test-transmission1",
         addition: "",
@@ -505,7 +505,7 @@ describe("base transmission", () => {
     // now send our events through separate transmissions with different user
     // agent additions.
     userAgents.forEach(userAgent => {
-      var transmission = new Transmission({
+      let transmission = new Transmission({
         batchSizeTrigger: 1, // so we'll send individual events
         responseCallback(queue) {
           let responses = queue.splice(0, queue.length);

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -1,6 +1,6 @@
 /* eslint-env node, jest */
-import net from "net";
 import { Transmission, ValidatedEvent } from "../transmission";
+import net from "net";
 
 let superagent = require("superagent");
 let mock = require("superagent-mocker")(superagent);

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -305,9 +305,9 @@ describe("base transmission", () => {
       pendingWorkCapacity: responseExpected,
       responseCallback(queue) {
         let responses = queue.splice(0, queue.length);
-        responses.forEach(({ error, status_code }) => {
+        responses.forEach(({ error, status_code: statusCode }) => {
           expect(error.status).toEqual(404);
-          expect(status_code).toEqual(404);
+          expect(statusCode).toEqual(404);
           responseCount++;
           if (responseCount === responseExpected) {
             done();

--- a/src/builder.js
+++ b/src/builder.js
@@ -17,10 +17,10 @@ export default class Builder {
    * @constructor
    * @private
    */
-  constructor(libhoney, fields, dyn_fields) {
+  constructor(libhoney, fields, dynFields) {
     this._libhoney = libhoney;
     this._fields = Object.create(null);
-    this._dyn_fields = Object.create(null);
+    this._dynFields = Object.create(null);
 
     /**
      * The hostname for the Honeycomb API server to which to send events created through this
@@ -54,7 +54,7 @@ export default class Builder {
     this.sampleRate = 1;
 
     foreach(fields, (v, k) => this.addField(k, v));
-    foreach(dyn_fields, (v, k) => this.addDynamicField(k, v));
+    foreach(dynFields, (v, k) => this.addDynamicField(k, v));
   }
 
   /**
@@ -104,11 +104,11 @@ export default class Builder {
    *   builder.addDynamicField("process_heapUsed", () => process.memoryUsage().heapUsed);
    */
   addDynamicField(name, fn) {
-    this._dyn_fields[name] = fn;
+    this._dynFields[name] = fn;
   }
 
   /**
-   * creates and sends an event, including all builder fields/dyn_fields, as well as anything in the optional data parameter.
+   * creates and sends an event, including all builder fields/dynFields, as well as anything in the optional data parameter.
    * @param {Object|Map<string, any>} [data] field->value mapping to add to the event sent.
    * @example <caption>empty sendNow</caption>
    *   builder.sendNow(); // sends just the data that has been added via add/addField/addDynamicField.
@@ -124,7 +124,7 @@ export default class Builder {
   }
 
   /**
-   * creates and returns a new Event containing all fields/dyn_fields from this builder, that can be further fleshed out and sent on its own.
+   * creates and returns a new Event containing all fields/dynFields from this builder, that can be further fleshed out and sent on its own.
    * @returns {Event} an Event instance
    * @example <caption>adding data at send-time</caption>
    *   let ev = builder.newEvent();
@@ -132,7 +132,7 @@ export default class Builder {
    *   ev.send();
    */
   newEvent() {
-    let ev = new Event(this._libhoney, this._fields, this._dyn_fields);
+    let ev = new Event(this._libhoney, this._fields, this._dynFields);
     ev.apiHost = this.apiHost;
     ev.writeKey = this.writeKey;
     ev.dataset = this.dataset;
@@ -141,9 +141,9 @@ export default class Builder {
   }
 
   /**
-   * creates and returns a clone of this builder, merged with fields and dyn_fields passed as arguments.
+   * creates and returns a clone of this builder, merged with fields and dynFields passed as arguments.
    * @param {Object|Map<string, any>} fields a field->value mapping to merge into the new builder.
-   * @param {Object|Map<string, any>} dyn_fields a field->dynamic function mapping to merge into the new builder.
+   * @param {Object|Map<string, any>} dynFields a field->dynamic function mapping to merge into the new builder.
    * @returns {Builder} a Builder instance
    * @example <caption>no additional fields/dyn_field</caption>
    *   let anotherBuilder = builder.newBuilder();
@@ -153,11 +153,11 @@ export default class Builder {
    *                                             process_heapUsed: () => process.memoryUsage().heapUsed
    *                                           });
    */
-  newBuilder(fields, dyn_fields) {
-    let b = new Builder(this._libhoney, this._fields, this._dyn_fields);
+  newBuilder(fields, dynFields) {
+    let b = new Builder(this._libhoney, this._fields, this._dynFields);
 
     foreach(fields, (v, k) => b.addField(k, v));
-    foreach(dyn_fields, (v, k) => b.addDynamicField(k, v));
+    foreach(dynFields, (v, k) => b.addDynamicField(k, v));
 
     b.apiHost = this.apiHost;
     b.writeKey = this.writeKey;

--- a/src/builder.js
+++ b/src/builder.js
@@ -88,7 +88,7 @@ export default class Builder {
    *   builder.addField("component", "web");
    */
   addField(name, val) {
-    if (val == undefined) {
+    if (val === undefined) {
       val = null;
     }
     this._fields[name] = val;

--- a/src/builder.js
+++ b/src/builder.js
@@ -118,7 +118,7 @@ export default class Builder {
    *   });
    */
   sendNow(data) {
-    var ev = this.newEvent();
+    let ev = this.newEvent();
     ev.add(data);
     ev.send();
   }
@@ -132,7 +132,7 @@ export default class Builder {
    *   ev.send();
    */
   newEvent() {
-    var ev = new Event(this._libhoney, this._fields, this._dyn_fields);
+    let ev = new Event(this._libhoney, this._fields, this._dyn_fields);
     ev.apiHost = this.apiHost;
     ev.writeKey = this.writeKey;
     ev.dataset = this.dataset;
@@ -154,7 +154,7 @@ export default class Builder {
    *                                           });
    */
   newBuilder(fields, dyn_fields) {
-    var b = new Builder(this._libhoney, this._fields, this._dyn_fields);
+    let b = new Builder(this._libhoney, this._fields, this._dyn_fields);
 
     foreach(fields, (v, k) => b.addField(k, v));
     foreach(dyn_fields, (v, k) => b.addDynamicField(k, v));

--- a/src/builder.js
+++ b/src/builder.js
@@ -89,7 +89,8 @@ export default class Builder {
    */
   addField(name, val) {
     if (val === undefined) {
-      val = null;
+      this._fields[name] = null;
+      return this;
     }
     this._fields[name] = val;
     return this;

--- a/src/event.js
+++ b/src/event.js
@@ -98,7 +98,8 @@ export default class Event {
    */
   addField(name, val) {
     if (val === undefined) {
-      val = null;
+      this.data[name] = null;
+      return this;
     }
     this.data[name] = val;
     return this;

--- a/src/event.js
+++ b/src/event.js
@@ -16,7 +16,7 @@ export default class Event {
    * @constructor
    * private
    */
-  constructor(libhoney, fields, dyn_fields) {
+  constructor(libhoney, fields, dynFields) {
     this.data = Object.create(null);
     this.metadata = null;
 
@@ -56,7 +56,7 @@ export default class Event {
     this.timestamp = null;
 
     foreach(fields, (v, k) => this.addField(k, v));
-    foreach(dyn_fields, (v, k) => this.addField(k, v()));
+    foreach(dynFields, (v, k) => this.addField(k, v()));
 
     // stash this away for .send()
     this._libhoney = libhoney;

--- a/src/event.js
+++ b/src/event.js
@@ -97,7 +97,7 @@ export default class Event {
    *     .send();
    */
   addField(name, val) {
-    if (val == undefined) {
+    if (val === undefined) {
       val = null;
     }
     this.data[name] = val;

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -366,7 +366,7 @@ export default class Libhoney extends EventEmitter {
   }
 
   /**
-   * creates and sends an event, including all global builder fields/dyn_fields, as well as anything in the optional data parameter.
+   * creates and sends an event, including all global builder fields/dynFields, as well as anything in the optional data parameter.
    * @param {Object|Map<string, any>} data field->value mapping.
    * @example <caption>using an object</caption>
    *   honey.sendNow ({
@@ -384,7 +384,7 @@ export default class Libhoney extends EventEmitter {
   }
 
   /**
-   * creates and returns a new Event containing all fields/dyn_fields from the global Builder, that can be further fleshed out and sent on its own.
+   * creates and returns a new Event containing all fields/dynFields from the global Builder, that can be further fleshed out and sent on its own.
    * @returns {Event} an Event instance
    * @example <caption>adding data at send-time</caption>
    *   let ev = honey.newEvent();
@@ -396,9 +396,9 @@ export default class Libhoney extends EventEmitter {
   }
 
   /**
-   * creates and returns a clone of the global Builder, merged with fields and dyn_fields passed as arguments.
+   * creates and returns a clone of the global Builder, merged with fields and dynFields passed as arguments.
    * @param {Object|Map<string, any>} fields a field->value mapping to merge into the new builder.
-   * @param {Object|Map<string, any>} dyn_fields a field->dynamic function mapping to merge into the new builder.
+   * @param {Object|Map<string, any>} dynFields a field->dynamic function mapping to merge into the new builder.
    * @returns {Builder} a Builder instance
    * @example <caption>no additional fields/dyn_field</caption>
    *   let builder = honey.newBuilder();
@@ -408,8 +408,8 @@ export default class Libhoney extends EventEmitter {
    *                                    process_heapUsed: () => process.memoryUsage().heapUsed
    *                                  });
    */
-  newBuilder(fields, dyn_fields) {
-    return this._builder.newBuilder(fields, dyn_fields);
+  newBuilder(fields, dynFields) {
+    return this._builder.newBuilder(fields, dynFields);
   }
 }
 

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -451,11 +451,11 @@ function getAndInitTransmission(transmission, options) {
 
   try {
     return new transmission(options);
-  } catch (e) {
+  } catch (initialisationError) {
     if (transmission === Transmission) {
       throw new Error(
         "unable to initialize base transmission implementation.",
-        e
+        initialisationError
       );
     }
 
@@ -464,10 +464,10 @@ function getAndInitTransmission(transmission, options) {
     );
     try {
       return new Transmission(options);
-    } catch (e) {
+    } catch (fallbackInitialisationError) {
       throw new Error(
         "unable to initialize base transmission implementation.",
-        e
+        fallbackInitialisationError
       );
     }
   }

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -413,36 +413,36 @@ export default class Libhoney extends EventEmitter {
   }
 }
 
+const getTransmissionClass = transmissionClassName => {
+  switch (transmissionClassName) {
+    case "base":
+      return Transmission;
+    case "mock":
+      return MockTransmission;
+    case "null":
+      return NullTransmission;
+    case "worker":
+      console.warn(
+        "worker implementation not ready yet.  using base implementation"
+      );
+      return Transmission;
+    case "writer":
+      return WriterTransmission;
+    default:
+      throw new Error(
+        `unknown transmission implementation "${transmissionClassName}".`
+      );
+  }
+};
+
 function getAndInitTransmission(transmission, options) {
   if (options.disabled) {
     return null;
   }
 
   if (typeof transmission === "string") {
-    switch (transmission) {
-      case "base":
-        transmission = Transmission;
-        break;
-      case "worker":
-        console.warn(
-          "worker implementation not ready yet.  using base implementation"
-        );
-        transmission = Transmission;
-        break;
-      case "mock":
-        transmission = MockTransmission;
-        break;
-      case "writer":
-        transmission = WriterTransmission;
-        break;
-      case "null":
-        transmission = NullTransmission;
-        break;
-      default:
-        throw new Error(
-          `unknown transmission implementation "${transmission}".`
-        );
-    }
+    const transmissionClass = getTransmissionClass(transmission);
+    return new transmissionClass(options);
   } else if (typeof transmission !== "function") {
     throw new Error(
       ".transmission must be one of 'base'/'worker'/'mock'/'writer'/'null' or a constructor."
@@ -463,7 +463,7 @@ function getAndInitTransmission(transmission, options) {
       "failed to initialize transmission, falling back to base implementation."
     );
     try {
-      transmission = new Transmission(options);
+      return new Transmission(options);
     } catch (e) {
       throw new Error(
         "unable to initialize base transmission implementation.",
@@ -471,8 +471,6 @@ function getAndInitTransmission(transmission, options) {
       );
     }
   }
-
-  return transmission;
 }
 
 // this will absolutely go away with the next major version bump.  right now in normal node (CJS) usage,

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -7,11 +7,11 @@
  * @module
  */
 import {
-  Transmission,
   MockTransmission,
-  WriterTransmission,
   NullTransmission,
-  ValidatedEvent
+  Transmission,
+  ValidatedEvent,
+  WriterTransmission
 } from "./transmission";
 import Builder from "./builder";
 

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -452,7 +452,7 @@ function getAndInitTransmission(transmission, options) {
   try {
     return new transmission(options);
   } catch (e) {
-    if (transmission == Transmission) {
+    if (transmission === Transmission) {
       throw new Error(
         "unable to initialize base transmission implementation.",
         e

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -267,7 +267,7 @@ export default class Libhoney extends EventEmitter {
   validateEvent(event) {
     if (!this._usable) return null;
 
-    var timestamp = event.timestamp || Date.now();
+    let timestamp = event.timestamp || Date.now();
     if (typeof timestamp === "string" || typeof timestamp === "number")
       timestamp = new Date(timestamp);
 
@@ -275,7 +275,7 @@ export default class Libhoney extends EventEmitter {
       console.error(".data must be an object");
       return null;
     }
-    var postData;
+    let postData;
     try {
       postData = JSON.stringify(event.data);
     } catch (e) {
@@ -283,31 +283,31 @@ export default class Libhoney extends EventEmitter {
       return null;
     }
 
-    var apiHost = event.apiHost;
+    let apiHost = event.apiHost;
     if (typeof apiHost !== "string" || apiHost === "") {
       console.error(".apiHost must be a non-empty string");
       return null;
     }
 
-    var writeKey = event.writeKey;
+    let writeKey = event.writeKey;
     if (typeof writeKey !== "string" || writeKey === "") {
       console.error(".writeKey must be a non-empty string");
       return null;
     }
 
-    var dataset = event.dataset;
+    let dataset = event.dataset;
     if (typeof dataset !== "string" || dataset === "") {
       console.error(".dataset must be a non-empty string");
       return null;
     }
 
-    var sampleRate = event.sampleRate;
+    let sampleRate = event.sampleRate;
     if (typeof sampleRate !== "number") {
       console.error(".sampleRate must be a number");
       return null;
     }
 
-    var metadata = event.metadata;
+    let metadata = event.metadata;
     return new ValidatedEvent({
       timestamp,
       apiHost,

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -178,19 +178,19 @@ export class Transmission {
     this._eventQueue = [];
     this._batchCount = 0;
 
-    if (typeof options.responseCallback == "function") {
+    if (typeof options.responseCallback === "function") {
       this._responseCallback = options.responseCallback;
     }
-    if (typeof options.batchSizeTrigger == "number") {
+    if (typeof options.batchSizeTrigger === "number") {
       this._batchSizeTrigger = Math.max(options.batchSizeTrigger, 1);
     }
-    if (typeof options.batchTimeTrigger == "number") {
+    if (typeof options.batchTimeTrigger === "number") {
       this._batchTimeTrigger = options.batchTimeTrigger;
     }
-    if (typeof options.maxConcurrentBatches == "number") {
+    if (typeof options.maxConcurrentBatches === "number") {
       this._maxConcurrentBatches = options.maxConcurrentBatches;
     }
-    if (typeof options.pendingWorkCapacity == "number") {
+    if (typeof options.pendingWorkCapacity === "number") {
       this._pendingWorkCapacity = options.pendingWorkCapacity;
     }
 
@@ -235,7 +235,7 @@ export class Transmission {
   }
 
   _sendBatch() {
-    if (this._batchCount == maxConcurrentBatches) {
+    if (this._batchCount === maxConcurrentBatches) {
       // don't start up another concurrent batch.  the next timeout/sendEvent or batch completion
       // will cause us to send another
       return;

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -33,8 +33,8 @@ const pendingWorkCapacity = 10000;
 const emptyResponseCallback = function() {};
 
 const eachPromise = (arr, iteratorFn) =>
-  arr.reduce(function(p, item) {
-    return p.then(function() {
+  arr.reduce((p, item) => {
+    return p.then(() => {
       return iteratorFn(item);
     });
   }, Promise.resolve());

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -245,9 +245,9 @@ export class Transmission {
 
     this._batchCount++;
 
-    let batch = this._eventQueue.splice(0, this._batchSizeTrigger);
-
-    let batchAgg = new BatchEndpointAggregator(batch);
+    let batchAgg = new BatchEndpointAggregator(
+      this._eventQueue.splice(0, this._batchSizeTrigger)
+    );
 
     const finishBatch = () => {
       this._batchCount--;
@@ -321,13 +321,13 @@ export class Transmission {
                       error: ev.encodeError
                     };
                   } else {
-                    let res = response[respIdx++];
+                    let nextResponse = response[respIdx++];
                     return {
                       // eslint-disable-next-line camelcase
-                      status_code: res.status,
+                      status_code: nextResponse.status,
                       duration: end - start,
                       metadata: ev.metadata,
-                      error: res.err
+                      error: nextResponse.err
                     };
                   }
                 })

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -7,8 +7,8 @@
 /**
  * @module
  */
-import superagent from "superagent";
 import proxy from "superagent-proxy";
+import superagent from "superagent";
 import urljoin from "urljoin";
 
 const USER_AGENT = "libhoney-js/<@LIBHONEY_JS_VERSION@>";

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -302,6 +302,7 @@ export class Transmission {
             if (err) {
               this._responseCallback(
                 batch.events.map(ev => ({
+                  // eslint-disable-next-line camelcase
                   status_code: ev.encodeError ? undefined : err.status,
                   duration: end - start,
                   metadata: ev.metadata,
@@ -322,6 +323,7 @@ export class Transmission {
                   } else {
                     let res = response[respIdx++];
                     return {
+                      // eslint-disable-next-line camelcase
                       status_code: res.status,
                       duration: end - start,
                       metadata: ev.metadata,

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -245,7 +245,7 @@ export class Transmission {
 
     this._batchCount++;
 
-    var batch = this._eventQueue.splice(0, this._batchSizeTrigger);
+    let batch = this._eventQueue.splice(0, this._batchSizeTrigger);
 
     let batchAgg = new BatchEndpointAggregator(batch);
 
@@ -264,8 +264,8 @@ export class Transmission {
 
     let batches = Object.keys(batchAgg.batches).map(k => batchAgg.batches[k]);
     eachPromise(batches, batch => {
-      var url = urljoin(batch.apiHost, "/1/batch", batch.dataset);
-      var req = superagent.post(url);
+      let url = urljoin(batch.apiHost, "/1/batch", batch.dataset);
+      let req = superagent.post(url);
       if (this._proxy) {
         req = proxy(req, this._proxy);
       }
@@ -290,7 +290,7 @@ export class Transmission {
           userAgent = `${USER_AGENT} ${trimmedAddition}`;
         }
 
-        var start = Date.now();
+        let start = Date.now();
         req
           .set("X-Hny-Team", batch.writeKey)
           .set("User-Agent", userAgent)
@@ -342,7 +342,7 @@ export class Transmission {
   }
 
   _shouldSendEvent(ev) {
-    var { sampleRate } = ev;
+    let { sampleRate } = ev;
     if (sampleRate <= 1) {
       return true;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,23 +810,27 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
-acorn-jsx@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
-  dependencies:
-    acorn "^5.0.3"
+acorn-jsx@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
+  integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
 
 acorn-walk@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.0.tgz#c957f4a1460da46af4a0388ce28b4c99355b0cbc"
 
-acorn@^5.0.3, acorn@^5.5.3, acorn@^5.6.0:
+acorn@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
 
 acorn@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.2.tgz#6a459041c320ab17592c6317abbfdf4bbaa98ca4"
+
+acorn@^6.0.7:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
 agent-base@4, agent-base@^4.1.0, agent-base@^4.2.0, agent-base@~4.2.0:
   version "4.2.1"
@@ -843,9 +847,10 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.5.3:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.4.tgz#247d5274110db653706b550fcc2b797ca28cfc59"
+ajv@^6.9.1:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -859,6 +864,11 @@ ansi-escapes@^1.0.0:
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
+
+ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -929,16 +939,6 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
-array-union@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  dependencies:
-    array-uniq "^1.0.1"
-
-array-uniq@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
@@ -947,7 +947,7 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-arrify@^1.0.0, arrify@^1.0.1:
+arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -1144,16 +1144,6 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-caller-path@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
-  dependencies:
-    callsites "^0.2.0"
-
-callsites@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
-
 callsites@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
@@ -1190,7 +1180,7 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -1198,7 +1188,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.4.2:
+chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1210,6 +1200,7 @@ chalk@^2.4.2:
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 ci-info@^1.5.0:
   version "1.6.0"
@@ -1219,10 +1210,6 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
-
-circular-json@^0.3.1:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -1242,6 +1229,7 @@ cli-cursor@^1.0.2:
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
 
@@ -1255,6 +1243,7 @@ cli-truncate@^0.2.1:
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -1374,6 +1363,7 @@ cross-spawn@^5.0.1:
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
   dependencies:
     nice-try "^1.0.4"
     path-key "^2.0.1"
@@ -1431,13 +1421,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -1501,18 +1485,6 @@ degenerator@^1.0.4:
     escodegen "1.x.x"
     esprima "3.x.x"
 
-del@^2.0.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
-  dependencies:
-    globby "^5.0.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    rimraf "^2.2.8"
-
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -1530,9 +1502,10 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
-doctrine@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
@@ -1557,6 +1530,11 @@ electron-to-chromium@^1.3.116:
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 end-of-stream@^1.1.0:
   version "1.4.1"
@@ -1614,9 +1592,10 @@ escodegen@1.x.x, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-scope@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+eslint-scope@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
@@ -1624,60 +1603,63 @@ eslint-scope@^4.0.0:
 eslint-utils@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^5.2.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.7.0.tgz#55c326d6fb2ad45fcbd0ce17c3846f025d1d819c"
+eslint@^5.15.3:
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.15.3.tgz#c79c3909dc8a7fa3714fb340c11e30fd2526b8b5"
+  integrity sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.5.3"
+    ajv "^6.9.1"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
-    doctrine "^2.1.0"
-    eslint-scope "^4.0.0"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.3"
     eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^4.0.0"
+    espree "^5.0.1"
     esquery "^1.0.1"
     esutils "^2.0.2"
-    file-entry-cache "^2.0.0"
+    file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
     globals "^11.7.0"
     ignore "^4.0.6"
+    import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.1.0"
-    is-resolvable "^1.1.0"
+    inquirer "^6.2.2"
     js-yaml "^3.12.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.17.5"
+    lodash "^4.17.11"
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
     path-is-inside "^1.0.2"
-    pluralize "^7.0.0"
     progress "^2.0.0"
     regexpp "^2.0.1"
-    require-uncached "^1.0.3"
     semver "^5.5.1"
     strip-ansi "^4.0.0"
     strip-json-comments "^2.0.1"
-    table "^5.0.2"
+    table "^5.2.3"
     text-table "^0.2.0"
 
-espree@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
+espree@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
+  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
   dependencies:
-    acorn "^5.6.0"
-    acorn-jsx "^4.1.1"
+    acorn "^6.0.7"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
 
 esprima@3.x.x, esprima@^3.1.3:
   version "3.1.3"
@@ -1690,12 +1672,14 @@ esprima@^4.0.0:
 esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
   dependencies:
     estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
   dependencies:
     estraverse "^4.1.0"
 
@@ -1806,9 +1790,10 @@ extend@~2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-2.0.2.tgz#1b74985400171b85554894459c978de6ef453ab7"
 
-external-editor@^3.0.0:
+external-editor@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
   dependencies:
     chardet "^0.7.0"
     iconv-lite "^0.4.24"
@@ -1848,6 +1833,7 @@ fast-deep-equal@^1.0.0:
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1873,15 +1859,16 @@ figures@^1.7.0:
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-entry-cache@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
-    flat-cache "^1.2.1"
-    object-assign "^4.0.1"
+    flat-cache "^2.0.1"
 
 file-uri-to-path@1:
   version "1.0.0"
@@ -1929,14 +1916,19 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-flat-cache@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
   dependencies:
-    circular-json "^0.3.1"
-    del "^2.0.2"
-    graceful-fs "^4.1.2"
-    write "^0.2.1"
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
+  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -1988,6 +1980,7 @@ function-bind@^1.1.1:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -2053,25 +2046,10 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.1.0:
+globals@^11.1.0, globals@^11.7.0:
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
   integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
-
-globals@^11.7.0:
-  version "11.8.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
-
-globby@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
-  dependencies:
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
@@ -2219,6 +2197,15 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-local@^2.0.0:
   version "2.0.0"
@@ -2247,22 +2234,23 @@ inherits@2, inherits@2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inquirer@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+inquirer@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
+  integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
   dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    external-editor "^3.0.0"
+    external-editor "^3.0.3"
     figures "^2.0.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
     mute-stream "0.0.7"
     run-async "^2.2.0"
-    rxjs "^6.1.0"
+    rxjs "^6.4.0"
     string-width "^2.1.0"
-    strip-ansi "^4.0.0"
+    strip-ansi "^5.0.0"
     through "^2.3.6"
 
 invariant@^2.2.2, invariant@^2.2.4:
@@ -2444,22 +2432,6 @@ is-observable@^1.1.0:
   dependencies:
     symbol-observable "^1.1.0"
 
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-
-is-path-in-cwd@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
-  dependencies:
-    is-path-inside "^1.0.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  dependencies:
-    path-is-inside "^1.0.1"
-
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -2487,10 +2459,6 @@ is-regex@^1.0.4:
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
-
-is-resolvable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -2983,7 +2951,15 @@ js-levenshtein@^1.1.3:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.12.0, js-yaml@^3.9.0:
+js-yaml@^3.12.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
+  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -3046,6 +3022,7 @@ json-schema-traverse@^0.3.0:
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -3054,6 +3031,7 @@ json-schema@0.2.3:
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -3407,6 +3385,7 @@ ms@^2.1.1:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -3440,6 +3419,7 @@ netmask@^1.0.6:
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3517,7 +3497,7 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -3572,6 +3552,7 @@ onetime@^1.0.0:
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
 
@@ -3678,6 +3659,13 @@ pac-resolver@^3.0.0:
     netmask "^1.0.6"
     thunkify "^2.1.2"
 
+parent-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.0.tgz#df250bdc5391f4a085fb589dad761f5ad6b865b5"
+  integrity sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==
+  dependencies:
+    callsites "^3.0.0"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -3710,7 +3698,7 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
@@ -3739,23 +3727,9 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pify@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-
-pinkie-promise@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  dependencies:
-    pinkie "^2.0.0"
-
-pinkie@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -3776,10 +3750,6 @@ please-upgrade-node@^3.0.2:
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
   dependencies:
     semver-compare "^1.0.0"
-
-pluralize@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -3828,8 +3798,9 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 progress@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prompts@^2.0.1:
   version "2.0.4"
@@ -3991,6 +3962,7 @@ regexp-tree@^0.1.0:
 regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
 regexpu-core@^4.1.3, regexpu-core@^4.5.4:
   version "4.5.4"
@@ -4075,26 +4047,20 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
-require-uncached@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
-  dependencies:
-    caller-path "^0.1.0"
-    resolve-from "^1.0.0"
-
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
   dependencies:
     resolve-from "^3.0.0"
 
-resolve-from@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
-
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -4127,6 +4093,7 @@ restore-cursor@^1.0.1:
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
@@ -4135,18 +4102,18 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-rimraf@^2.2.8, rimraf@^2.5.4:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
-  dependencies:
-    glob "^7.0.5"
-
-rimraf@^2.6.2:
+rimraf@2.6.3, rimraf@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@^2.5.4:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
 
 rollup-plugin-commonjs@^9.1.4:
   version "9.2.0"
@@ -4201,12 +4168,20 @@ rsvp@^4.8.4:
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
     is-promise "^2.1.0"
 
 rxjs@^6.1.0:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   dependencies:
     tslib "^1.9.0"
 
@@ -4309,10 +4284,13 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-slice-ansi@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
   dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
 smart-buffer@^4.0.1:
@@ -4488,6 +4466,15 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -4518,7 +4505,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -4595,14 +4582,15 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-table@^5.0.2:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.1.0.tgz#69a54644f6f01ad1628f8178715b408dc6bf11f7"
+table@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
+  integrity sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==
   dependencies:
-    ajv "^6.5.3"
-    lodash "^4.17.10"
-    slice-ansi "1.0.0"
-    string-width "^2.1.1"
+    ajv "^6.9.1"
+    lodash "^4.17.11"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 test-exclude@^5.0.0:
   version "5.1.0"
@@ -4617,6 +4605,7 @@ test-exclude@^5.0.0:
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
 throat@^4.0.0:
   version "4.1.0"
@@ -4624,7 +4613,8 @@ throat@^4.0.0:
 
 through@^2.3.6:
   version "2.3.8"
-  resolved "http://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 thunkify@^2.1.2:
   version "2.1.2"
@@ -4633,6 +4623,7 @@ thunkify@^2.1.2:
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
 
@@ -4757,6 +4748,7 @@ unset-value@^1.0.0:
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
 
@@ -4884,9 +4876,10 @@ write-file-atomic@2.4.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
 


### PR DESCRIPTION
Added a few common linting rules lifted liberally from AirBnB's ESLint config. These help improve readability, and standardise code style throughout the codebase.

The diff is a little messy but viewing each commit individually should make this a little easier to review.