### PR TITLE
Drop support for unsupported version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - '6'
   - '8'
-  - '9'
   - '10'
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - '6'
   - '8'
   - '10'
+  - '11'
 
 before_script:
   - yarn

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Node.js module for sending events to [Honeycomb](https://www.honeycomb.io), a 
 
 **NOTE** For use in browser-side JavaScript applications, generate an API key that has permission only to send events.
 
-Requires any current LTS release of Node.js. Currently v6, v8, and v10.
+Requires any current LTS release of Node.js. Currently v6, v8, and v10. Also tested against v11 but not guaranteed until LTS.
 
 - [Usage and Examples](https://docs.honeycomb.io/sdk/javascript/)
 - [API Reference](https://doc.esdoc.org/github.com/honeycombio/libhoney-js/)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # libhoney [![Build Status](https://travis-ci.org/honeycombio/libhoney-js.svg?branch=master)](https://travis-ci.org/honeycombio/libhoney-js) [![npm version](https://badge.fury.io/js/libhoney.svg)](https://badge.fury.io/js/libhoney)
 
-A nodeJS module for sending events to [Honeycomb](https://www.honeycomb.io), a service for debugging your software in production.
+A Node.js module for sending events to [Honeycomb](https://www.honeycomb.io), a service for debugging your software in production.
 
-**NOTE** For use in browser-side JavaScript applications, generate an api key that has permission only to send events.
+**NOTE** For use in browser-side JavaScript applications, generate an API key that has permission only to send events.
 
-Requires node 4+.
+Requires any current LTS release of Node.js. Currently v6, v8, and v10.
 
 - [Usage and Examples](https://docs.honeycomb.io/sdk/javascript/)
 - [API Reference](https://doc.esdoc.org/github.com/honeycombio/libhoney-js/)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/honeycombio/libhoney-js.git"
   },
+  "engines": {
+    "node": "6.* || 8.* || >= 10.*"
+  },
   "module": "dist/libhoney.es.js",
   "main": "dist/libhoney.cjs.js",
   "files": ["dist", "README.md", "LICENSE"],


### PR DESCRIPTION
v9 has been EOL since June 2018. Only versions 6, 8, and 10+ continue to
be supported. Supporting v9 is causing issues with dependent libraries
as seen here: https://travis-ci.org/honeycombio/libhoney-js/jobs/511749577

More info on supported versions here: https://github.com/nodejs/Release

NOTE: Once this is merged, re-running CI on PR #45 will make it pass successfully.