### PR TITLE
stop relying on npm publish not allowing us to overwrite a version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,6 @@ workflows:
             - test_node12
           filters:
             tags:
-              only: /^.*/
+              only: /.*/
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+tag_filters: &tag_filters
+  filters:
+      tags:
+        only: /.*/
+
 executors:
   node:
     parameters:
@@ -44,15 +49,19 @@ workflows:
       - test_libhoney:
           name: test_node8
           nodeversion: "8"
+          filters: *tag_filters
       - test_libhoney:
           name: test_node10
           nodeversion: "10"
+          filters: *tag_filters
       - test_libhoney:
           name: test_node11
           nodeversion: "11"
+          filters: *tag_filters
       - test_libhoney:
           name: test_node12
           nodeversion: "12"
+          filters: *tag_filters
       - publish:
           requires:
             - test_node8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ workflows:
             - test_node11
             - test_node12
           filters:
-              branches:
-                only: master
-              tags:
-                only: /.+/
+            tags:
+              only: /^.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,8 @@
 version: 2.1
 
 tag_filters: &tag_filters
-  filters:
-      tags:
-        only: /.*/
+    tags:
+      only: /.*/
 
 executors:
   node:


### PR DESCRIPTION
currently our circleci config attempts to publish for any master commit, which is.. bad.  It should only happen for tags.

I can never remember the branches/tags stuff, so I copied elements of the ruby libhoney/beeline config with the tag regexp tailored to libhoney-js's tags.