### PR TITLE
CORS hotfix

### DIFF
--- a/src/transmission.js
+++ b/src/transmission.js
@@ -311,7 +311,7 @@ export class Transmission {
 
         let start = Date.now();
         req
-          .set("X-Hny-Team", batch.writeKey)
+          .set("X-Honeycomb-Team", batch.writeKey)
           .set("User-Agent", userAgent)
           .type("json")
           .send(encoded)


### PR DESCRIPTION
Sync` Access-Control-Request-Headers` with expected value already exposed in `Access-Control-Allow-Headers`
this simply adjusts request `X-Hny-Team` to `X-Honeycomb-Team`

relates to #60 