### PR TITLE
Move babel-eslint to a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@babel/core": "^7.4.0",
     "@babel/preset-env": "^7.4.2",
+    "babel-eslint": "^10.0.3",
     "babel-jest": "^24.5.0",
     "babel-polyfill": "^6.26.0",
     "eslint": "^6.5.1",
@@ -51,7 +52,6 @@
     "superagent-mocker": "^0.5.2"
   },
   "dependencies": {
-    "babel-eslint": "^10.0.3",
     "superagent": "^3.8.3",
     "superagent-proxy": "^2.0.0",
     "urljoin": "^0.1.5"


### PR DESCRIPTION
I'm sure this was meant as a dev dependency to begin with, so just a small fix.

Fixes:
Annoying warning seen by any honeycomb-beeline user: "warning "honeycomb-beeline > libhoney > babel-eslint@10.1.0" has unmet peer dependency "eslint@>= 4.12.1"."
Reduces honecomb-beeline install by 9.4MB (!)

cc @daiyi 