### PR TITLE
fix User-Agent and superagent-proxy issues by building a browser bundle

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
     "no-var": "error",
     "eqeqeq": "error",
     "comma-dangle": "error",
-    "quotes": "error",
+    "quotes": ["error", "double", { "avoidEscape": true }],
     "camelcase": "error",
     "sort-imports": "error",
     "no-param-reassign": "error",

--- a/package.json
+++ b/package.json
@@ -10,17 +10,20 @@
   "engines": {
     "node": "8.* || >= 10.*"
   },
+  "browser": "dist/libhoney.browser.js",
   "module": "dist/libhoney.es.js",
   "main": "dist/libhoney.cjs.js",
   "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
-    "build": "rollup -c",
+    "build": "yarn build:node && yarn build:browser",
+    "build:node": "rollup -c rollup.config.js",
+    "build:browser": "rollup -c rollup.browser.config.js",
     "dev": "rollup -c -w",
     "test": "jest",
     "test-coverage": "jest --coverage",
-    "format": "prettier --write \"src/**/*.js\"",
-    "check-format": "prettier \"src/**/*.js\"",
-    "lint": "eslint \"src/**/*.js\"",
+    "format": "prettier --write \"src/**/*.js\" rollup.config.js rollup.browser.config.js",
+    "check-format": "prettier \"src/**/*.js\" rollup.config.js rollup.browser.config.js",
+    "lint": "eslint \"src/**/*.js\" rollup.config.js rollup.browser.config.js",
     "precommit": "lint-staged"
   },
   "author": "",

--- a/rollup.browser.config.js
+++ b/rollup.browser.config.js
@@ -18,18 +18,14 @@ module.exports = {
       LIBHONEY_JS_VERSION: pkg.version
     }),
     replace({
-      "process.env.LIBHONEY_TARGET": '"node"'
+      "process.env.LIBHONEY_TARGET": '"browser"'
     })
   ],
 
   output: [
     {
-      file: pkg.main,
+      file: pkg.browser,
       format: "cjs"
-    },
-    {
-      file: pkg.module,
-      format: "es"
     }
   ]
 };

--- a/rollup.browser.config.js
+++ b/rollup.browser.config.js
@@ -22,10 +22,5 @@ module.exports = {
     })
   ],
 
-  output: [
-    {
-      file: pkg.browser,
-      format: "cjs"
-    }
-  ]
+  output: [{ file: pkg.browser, format: "cjs" }]
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,13 +23,7 @@ module.exports = {
   ],
 
   output: [
-    {
-      file: pkg.main,
-      format: "cjs"
-    },
-    {
-      file: pkg.module,
-      format: "es"
-    }
+    { file: pkg.main, format: "cjs" },
+    { file: pkg.module, format: "es" }
   ]
 };

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -571,7 +571,15 @@ describe("base transmission", () => {
 
   it("should use X-Honeycomb-UserAgent in browser", done => {
     // terrible hack to get our "are we running in node" check to return false
+    const oldProcess = global.process;
     global.process = undefined;
+
+    let transmission = new Transmission({
+      batchTimeTrigger: 10000, // larger than the mocha timeout
+      batchSizeTrigger: 0
+    });
+
+    global.process = oldProcess;
 
     mock.post("http://localhost:9999/1/batch/browser-test", req => {
       if (req.headers["user-agent"]) {
@@ -585,11 +593,6 @@ describe("base transmission", () => {
       done();
 
       return {};
-    });
-
-    let transmission = new Transmission({
-      batchTimeTrigger: 10000, // larger than the mocha timeout
-      batchSizeTrigger: 0
     });
 
     transmission.sendPresampledEvent(

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -571,15 +571,12 @@ describe("base transmission", () => {
 
   it("should use X-Honeycomb-UserAgent in browser", done => {
     // terrible hack to get our "are we running in node" check to return false
-    const oldProcess = global.process;
-    global.process = undefined;
+    process.env.LIBHONEY_TARGET = "browser";
 
     let transmission = new Transmission({
       batchTimeTrigger: 10000, // larger than the mocha timeout
       batchSizeTrigger: 0
     });
-
-    global.process = oldProcess;
 
     mock.post("http://localhost:9999/1/batch/browser-test", req => {
       if (req.headers["user-agent"]) {
@@ -591,6 +588,8 @@ describe("base transmission", () => {
       }
 
       done();
+
+      process.env.LIBHONEY_TARGET = "";
 
       return {};
     });

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -196,6 +196,9 @@ export class Transmission {
     this._userAgentAddition = options.userAgentAddition || "";
     this._proxy = options.proxy;
 
+    const _isNode = typeof process !== "undefined";
+    this._UserAgentHeader = _isNode ? "User-Agent" : "X-Honeycomb-UserAgent";
+
     // Included for testing; to stub out randomness and verify that an event
     // was dropped.
     this._randomFn = Math.random;
@@ -314,15 +317,10 @@ export class Transmission {
               userAgent = `${USER_AGENT} ${trimmedAddition}`;
             }
 
-            const _isNode = typeof process !== "undefined";
-            const UserAgentHeader = _isNode
-              ? "User-Agent"
-              : "X-Honeycomb-UserAgent";
-
             let start = Date.now();
             req
               .set("X-Honeycomb-Team", batch.writeKey)
-              .set(UserAgentHeader, userAgent)
+              .set(this._UserAgentHeader, userAgent)
               .type("json")
               .send(encoded)
               .end((err, res) => {

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -314,10 +314,15 @@ export class Transmission {
               userAgent = `${USER_AGENT} ${trimmedAddition}`;
             }
 
+            const _isNode = typeof process !== "undefined";
+            const UserAgentHeader = _isNode
+              ? "User-Agent"
+              : "X-Honeycomb-UserAgent";
+
             let start = Date.now();
             req
               .set("X-Honeycomb-Team", batch.writeKey)
-              .set("User-Agent", userAgent)
+              .set(UserAgentHeader, userAgent)
               .type("json")
               .send(encoded)
               .end((err, res) => {


### PR DESCRIPTION
Some browsers log to the console if JS makes an XHR with a custom `User-Agent` header.  Regardless of the console output, all browsers disallow JS setting it, so at the API we lose version info.

Instead of trying to autodetect, add a `browser` bundle that uses the `X-Honeycomb-UserAgent`, and also removes the `superagent-proxy` import entirely.

Fixes #67 
Fixes #63 