### PR TITLE
add a timeout for an entire batch send/response of 60s

### DIFF
--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -615,7 +615,7 @@ describe("base transmission", () => {
     );
   });
 
-  it("should respect options.deadlineTimeoutMs and fail sending the batch", done => {
+  it("should respect options.timeout and fail sending the batch", done => {
     // we can't use superagent-mocker here, since we want the request to timeout,
     // and there's no async flow in -mocker :(
 

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -626,7 +626,8 @@ describe("base transmission", () => {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end("[{ status: 666 }]");
         },
-        // because this number is longer than our 5000 timeout.
+        // because this number is longer than our 5000 global test timeout, as well as (more importantly)
+        // the `timeout: 2000` below.
         7500
       );
     });

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -51,6 +51,9 @@ const defaults = Object.freeze({
   // the maximum number of responses we enqueue before we begin dropping them.
   maxResponseQueueSize: 1000,
 
+  // how long (in ms) to give a single POST before we timeout.
+  timeout: 60000,
+
   // if this is set to true, all sending is disabled.  useful for disabling libhoney when testing
   disabled: false,
 
@@ -81,6 +84,7 @@ export default class Libhoney extends EventEmitter {
    * @param {number} [opts.maxConcurrentBatches=10] - We process batches concurrently to increase parallelism while sending.
    * @param {number} [opts.pendingWorkCapacity=10000] - The maximum number of pending events we allow to accumulate in our sending queue before dropping them.
    * @param {number} [opts.maxResponseQueueSize=1000] - The maximum number of responses we enqueue before dropping them.
+   * @param {number} [opts.timeout=60000] - How long (in ms) to give a single POST before we timeout.
    * @param {boolean} [opts.disabled=false] - Disable transmission of events to the specified `apiHost`, particularly useful for testing or development.
    * @constructor
    * @example

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -29,6 +29,9 @@ const maxConcurrentBatches = 10;
 // how many events to queue up for busy batches before we start dropping
 const pendingWorkCapacity = 10000;
 
+// how long (in ms) to give a single POST before we timeout
+const deadlineTimeoutMs = 60000;
+
 const emptyResponseCallback = function() {};
 
 const eachPromise = (arr, iteratorFn) =>
@@ -173,6 +176,7 @@ export class Transmission {
     this._batchTimeTrigger = batchTimeTrigger;
     this._maxConcurrentBatches = maxConcurrentBatches;
     this._pendingWorkCapacity = pendingWorkCapacity;
+    this._timeout = deadlineTimeoutMs;
     this._sendTimeoutId = -1;
     this._eventQueue = [];
     this._batchCount = 0;
@@ -191,6 +195,9 @@ export class Transmission {
     }
     if (typeof options.pendingWorkCapacity === "number") {
       this._pendingWorkCapacity = options.pendingWorkCapacity;
+    }
+    if (typeof options.timeout === "number") {
+      this._timeout = options.timeout;
     }
 
     this._userAgentAddition = options.userAgentAddition || "";
@@ -329,6 +336,7 @@ export class Transmission {
                 userAgent
               )
               .type("json")
+              .timeout(this._timeout)
               .send(encoded)
               .end((err, res) => {
                 let end = Date.now();


### PR DESCRIPTION
Most of the fix for https://github.com/honeycombio/beeline-nodejs/issues/201 (will still need to add the config parameter there as well to pass on to libhoney).

Adds a `timeout` config option to the libhoney (and transmission), and respect it when doing a `POST`.

also clean up the superagent-mocker between tests so we can actually have an unmocked test.  superagent-mocker doesn't allow for async mocks 🤯 so we have to run an actual http server as part of this particular test in order to simulate a timeout.