### PR TITLE
add "console" transmission implementation which outputs valid parseable JSON event objects.  deprecate "writer" transmission implementation.

### DIFF
--- a/src/__tests__/builder_test.js
+++ b/src/__tests__/builder_test.js
@@ -53,7 +53,7 @@ describe("libhoney builder", () => {
     builder.sendNow({ c: { d: 2 } });
 
     expect(transmission.events).toHaveLength(1);
-    expect(transmission.events[0].postData).toEqual(JSON.stringify(postData));
+    expect(transmission.events[0].postData).toEqual(postData);
   });
 
   it("includes snapshot of global fields/dynFields", () => {
@@ -75,7 +75,7 @@ describe("libhoney builder", () => {
     builder.sendNow({ c: 3 });
 
     expect(transmission.events).toHaveLength(1);
-    expect(transmission.events[0].postData).toEqual(JSON.stringify(postData));
+    expect(transmission.events[0].postData).toEqual(postData);
 
     // but if we create another builder, it should show up in the post data.
     postData = { a: 1, b: 2, c: 3 };
@@ -85,6 +85,6 @@ describe("libhoney builder", () => {
     builder.sendNow({ c: 3 });
 
     expect(transmission.events).toHaveLength(2);
-    expect(transmission.events[1].postData).toEqual(JSON.stringify(postData));
+    expect(transmission.events[1].postData).toEqual(postData);
   });
 });

--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -41,7 +41,7 @@ describe("libhoney", () => {
       expect(transmission.events[0].dataset).toEqual("testing");
       expect(transmission.events[0].sampleRate).toEqual(1);
       expect(transmission.events[0].timestamp).toBeInstanceOf(Date);
-      expect(transmission.events[0].postData).toEqual(JSON.stringify(postData));
+      expect(transmission.events[0].postData).toEqual(postData);
     });
 
     it("should come from libhoney options if not specified in event", () => {
@@ -59,7 +59,7 @@ describe("libhoney", () => {
       expect(transmission.events[0].apiHost).toEqual("http://foo/bar");
       expect(transmission.events[0].writeKey).toEqual("12345");
       expect(transmission.events[0].dataset).toEqual("testing");
-      expect(transmission.events[0].postData).toEqual(JSON.stringify(postData));
+      expect(transmission.events[0].postData).toEqual(postData);
     });
   });
 

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -281,9 +281,9 @@ export default class Libhoney extends EventEmitter {
     }
     let postData;
     try {
-      postData = JSON.stringify(event.data);
+      postData = JSON.parse(JSON.stringify(event.data));
     } catch (e) {
-      console.error("error converting event data to JSON: " + e);
+      console.error("error cloning event data: " + e);
       return null;
     }
 

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -7,6 +7,7 @@
  * @module
  */
 import {
+  ConsoleTransmission,
   MockTransmission,
   NullTransmission,
   Transmission,
@@ -33,7 +34,8 @@ const defaults = Object.freeze({
   //  - "base": the default transmission implementation
   //  - "worker": a web-worker based transmission (not currently available, see https://github.com/honeycombio/libhoney-js/issues/22)
   //  - "mock": an implementation that accumulates all events sent
-  //  - "writer": an implementation that logs to the console all events sent
+  //  - "writer": an implementation that logs to the console all events sent (deprecated.  use "console" instead)
+  //  - "console": an implementation that logs correct json objects to the console for all events sent.
   //  - "null": an implementation that does nothing
   transmission: "base",
 
@@ -448,7 +450,12 @@ const getTransmissionClass = transmissionClassName => {
       );
       return Transmission;
     case "writer":
+      console.warn(
+        "writer implementation is deprecated.  Please switch to console implementation."
+      );
       return WriterTransmission;
+    case "console":
+      return ConsoleTransmission;
     default:
       throw new Error(
         `unknown transmission implementation "${transmissionClassName}".`
@@ -466,7 +473,7 @@ function getAndInitTransmission(transmission, options) {
     return new transmissionClass(options);
   } else if (typeof transmission !== "function") {
     throw new Error(
-      ".transmission must be one of 'base'/'worker'/'mock'/'writer'/'null' or a constructor."
+      ".transmission must be one of 'base'/'worker'/'mock'/'writer'/'console'/'null' or a constructor."
     );
   }
 

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -77,7 +77,7 @@ class BatchEndpointAggregator {
     let numEncoded = 0;
     let encodedEvents = events.reduce((acc, ev) => {
       try {
-        let encodedEvent = ev.toJSON(); // directly call toJSON, not JSON.stringify, because the latter wraps it in an additional set of quotes
+        let encodedEvent = JSON.stringify(ev);
         numEncoded++;
         let newAcc = acc + (!first ? "," : "") + encodedEvent;
         first = false;
@@ -116,17 +116,17 @@ export class ValidatedEvent {
   }
 
   toJSON() {
-    let fields = [];
+    let json = {};
     if (this.timestamp) {
-      fields.push(`"time":${JSON.stringify(this.timestamp)}`);
+      json.time = this.timestamp;
     }
     if (this.sampleRate) {
-      fields.push(`"samplerate":${JSON.stringify(this.sampleRate)}`);
+      json.samplerate = this.sampleRate;
     }
     if (this.postData) {
-      fields.push(`"data":${this.postData}`);
+      json.data = this.postData;
     }
-    return `{${fields.join(",")}}`;
+    return json;
   }
 }
 

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -128,6 +128,20 @@ export class ValidatedEvent {
     }
     return json;
   }
+
+  toBrokenJSON() {
+    let fields = [];
+    if (this.timestamp) {
+      fields.push(`"time":${JSON.stringify(this.timestamp)}`);
+    }
+    if (this.sampleRate) {
+      fields.push(`"samplerate":${JSON.stringify(this.sampleRate)}`);
+    }
+    if (this.postData) {
+      fields.push(`"data":${JSON.stringify(this.postData)}`);
+    }
+    return `{${fields.join(",")}}`;
+  }
 }
 
 export class MockTransmission {
@@ -150,7 +164,18 @@ export class MockTransmission {
   }
 }
 
+// deprecated.  Use ConsoleTransmission instead.
 export class WriterTransmission {
+  sendEvent(ev) {
+    console.log(JSON.stringify(ev.toBrokenJSON()));
+  }
+
+  sendPresampledEvent(ev) {
+    console.log(JSON.stringify(ev.toBrokenJSON()));
+  }
+}
+
+export class ConsoleTransmission {
   sendEvent(ev) {
     console.log(JSON.stringify(ev));
   }


### PR DESCRIPTION
while testing the `writer` transmission for https://github.com/honeycombio/beeline-nodejs/issues/221, I noticed that we're double quoting (as in quoting twice, not using double quotes) the json that we send to stdout.

Rather than stomaching a breaking change, introduce a new transmission implementation called `console`, which will output proper parseable events to the console.

using `writer`:
```
"{\"time\":\"2020-07-10T20:39:53.747Z\",\"samplerate\":1,\"data\":{\"meta.local_hostname\":\"MacBook-Pro-3.local\",\"service_name\":null,\"name\":\"fast-child\",\"trace.trace_id\":\"1de121e83672afcfb8253c03718c9a34\",\"trace.span_id\":\"f98f71ce844e16e2\",\"trace.parent_id\":\"a74e2500137cabbb\",\"duration_ms\":1.666767,\"meta.instrumentations\":[],\"meta.instrumentation_count\":0,\"meta.beeline_version\":\"2.1.1\",\"meta.node_version\":\"v10.21.0\"}}"
```

using `console`:
```
{"time":"2020-07-10T20:47:57.204Z","samplerate":1,"data":{"meta.local_hostname":"MacBook-Pro-3.local","service_name":null,"name":"fast-child","trace.trace_id":"f633a967b2fcdf37f7d5f9a8b7d0a604","trace.span_id":"1c1efb489c87ee7e","trace.parent_id":"30f4932d66df55e6","duration_ms":0.366734,"meta.instrumentations":[],"meta.instrumentation_count":0,"meta.beeline_version":"2.1.1","meta.node_version":"v10.21.0"}}
```

deprecate the `writer` implementation. we can nuke it next major bump.