### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
 root = true
 
 [*]
-indent_style = space
-indent_size = 4
 charset = utf-8
+end_of_line = lf
+insert_final_newline = true
 trim_trailing_whitespace = true
-insert_final_newline = false
+indent_size = 2
+indent_style = space
+
+[{Makefile,*.mk}]
+indent_style = tab
 
 [*.md]
+indent_size = 4
 trim_trailing_whitespace = false


### PR DESCRIPTION
Adds a simple editor config for use with .js files (eg spaces over tabs).