### PR TITLE
Modernize circleci, add publish_github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,70 @@
 version: 2.1
 
-tag_filters: &tag_filters
+# YAML Anchors to reduce copypasta
+
+# This is necessary for job to run when a tag is created
+filters_always: &filters_always
+  filters:
     tags:
       only: /.*/
+
+# Restrict running to only be on tags starting with vNNNN
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
+
+matrix_nodeversions: &matrix_nodeversions
+  matrix:
+    parameters:
+      nodeversion: ["8", "10", "11", "12", "14"]
+
+# Default version of node to use for lint and publishing
+default_nodeversion: &default_nodeversion "12"
 
 executors:
   node:
     parameters:
       nodeversion:
         type: string
-        default: "12"
+        default: *default_nodeversion
     docker:
       - image: circleci/node:<< parameters.nodeversion >>
+  github:
+    docker:
+      - image: cibuilds/github:0.13.0
+
+commands:
+  publish_github:
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Artifacts being published"
+          command: |
+            echo "about to publish to tag ${CIRCLE_TAG}"
+            ls -l ~/artifacts/*
+      - run:
+          name: "GHR Draft"
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
 
 jobs:
-  test_libhoney:
+  lint:
+    executor:
+      name: node
+      nodeversion: *default_nodeversion
+    steps:
+      - checkout
+      - run: yarn
+      - run: yarn lint
+
+  test:
     parameters:
       nodeversion:
         type: string
-        default: "12"
+        default: *default_nodeversion
     executor:
       name: node
       nodeversion: "<< parameters.nodeversion >>"
@@ -27,22 +73,40 @@ jobs:
       - run: yarn
       - run: yarn test
       - run: yarn build
-      
-  publish:
-    docker:
-      - image: circleci/node:12.12.0-buster
+
+  build_artifacts:
+    executor:
+      name: node
+    steps:
+      - checkout
+      - run: mkdir -p ~/artifacts
+      - run: yarn
+      - run: yarn build
+      - run: cp ./libhoney-*.tgz ~/artifacts/
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - artifacts
+      - store_artifacts:
+          path: ~/artifacts
+
+  publish_github:
+    executor: github
+    steps:
+      - publish_github
+
+  publish_npm:
+    executor:
+      name: node
     steps:
       - checkout
       - run:
           name: store npm auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: yarn
-      - run: yarn lint
-      - run: yarn build
       - run: npm publish
 
 workflows:
-  version: 2
   nightly:
     triggers:
       - schedule:
@@ -52,49 +116,32 @@ workflows:
               only:
                 - main
     jobs:
-      - test_libhoney:
-          name: test_node8
-          nodeversion: "8"
-          filters: *tag_filters
-      - test_libhoney:
-          name: test_node10
-          nodeversion: "10"
-          filters: *tag_filters
-      - test_libhoney:
-          name: test_node11
-          nodeversion: "11"
-          filters: *tag_filters
-      - test_libhoney:
-          name: test_node12
-          nodeversion: "12"
-          filters: *tag_filters
-
-  build-libhoney:
-    jobs:
-      - test_libhoney:
-          name: test_node8
-          nodeversion: "8"
-          filters: *tag_filters
-      - test_libhoney:
-          name: test_node10
-          nodeversion: "10"
-          filters: *tag_filters
-      - test_libhoney:
-          name: test_node11
-          nodeversion: "11"
-          filters: *tag_filters
-      - test_libhoney:
-          name: test_node12
-          nodeversion: "12"
-          filters: *tag_filters
-      - publish:
+      - lint
+      - test:
           requires:
-            - test_node8
-            - test_node10
-            - test_node11
-            - test_node12
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+            - lint
+          <<: *matrix_nodeversions
+
+  build:
+    jobs:
+      - lint:
+          <<: *filters_always
+      - test:
+          <<: *filters_always
+          requires:
+            - lint
+          <<: *matrix_nodeversions
+      - build_artifacts:
+          <<: *filters_always
+          requires:
+            - test
+      - publish_github:
+          <<: *filters_publish
+          context: Honeycomb Secrets
+          requires:
+            - build_artifacts
+      - publish_npm:
+          <<: *filters_publish
+          context: Honeycomb Secrets
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       - run: mkdir -p ~/artifacts
       - run: yarn
       - run: yarn build
-      - run: cp ./libhoney-*.tgz ~/artifacts/
+      - run: cp ./dist/* ~/artifacts/
       - persist_to_workspace:
           root: ~/
           paths:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A Node.js module for sending events to [Honeycomb](https://www.honeycomb.io), a 
 
 Requires any current LTS release of Node.js. Currently v8, and >= v10.
 
-- [Usage and Examples](https://docs.honeycomb.io/sdk/javascript/)
-- [API Reference](https://doc.esdoc.org/github.com/honeycombio/libhoney-js/)
+-   [Usage and Examples](https://docs.honeycomb.io/sdk/javascript/)
+-   [API Reference](https://doc.esdoc.org/github.com/honeycombio/libhoney-js/)
 
 For tracing support and automatic instrumentation of Express and other common libraries, check out our [Beeline for NodeJS](https://github.com/honeycombio/beeline-nodejs).
 
@@ -21,4 +21,6 @@ All contributions will be released under the Apache License 2.0.
 
 ### Releasing a new version
 
-Travis will automatically upload tagged releases to NPM.
+Use `npm version --no-git-tag-version` to update the version number using `major`, `minor`, `patch`, or the prerelease variants `premajor`, `preminor`, or `prepatch`. We use `--no-git-tag-version` to avoid automatically tagging - tagging with the version automatically triggers a CI run that publishes, and we only want to do that upon merging the PR into `main`.
+
+After doing this, follow our usual instructions for the actual process of tagging and releasing the package.


### PR DESCRIPTION
Similar to what was just done for beeline-nodejs:

* Updates to the CircleCI build process so that it more closely matches our "state of the art" process, including:
    * Matrix for node versions
    * Publish to github releases in addition to npm.
    * General cleanup
* Added CHANGELOG.md
* Instructions for using npm version to update the build number.

(Note: The build yellow because I changed the name of the CircleCI check from build-libhoney to build, I will change this in the github configuration as soon as the PR is signed off.)