### PR TITLE
Use public CircleCI context for build secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,11 +137,11 @@ workflows:
             - test
       - publish_github:
           <<: *filters_publish
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build_artifacts
       - publish_npm:
           <<: *filters_publish
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - test


### PR DESCRIPTION
* we created a new public context that's identical to the old context,
with the exception of Github token, which is scoped to public repos only
* Github token in the other context is scoped to public and private repos
* (both contexts are still internal to Honeycomb)
* this reduces the security exposure of builds