### PR TITLE
Improve transmission unit tests

### DIFF
--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -1,4 +1,5 @@
 /* eslint-env node, jest */
+import { MockTransmission } from "../transmission";
 import libhoney from "../libhoney";
 
 let superagent = require("superagent");
@@ -6,18 +7,29 @@ let mock = require("superagent-mocker")(superagent);
 
 describe("libhoney", () => {
   describe("constructor options", () => {
-    it("should be communicated to transmission constructor", () => {
-      let options = { a: 1, b: 2, c: 3, d: 4, transmission: "mock" };
+    describe.each(["mock", MockTransmission])(
+      "with %p transmission",
+      transmissionSpec => {
+        it("should be communicated to transmission constructor", () => {
+          const options = {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+            transmission: transmissionSpec
+          };
 
-      let honey = new libhoney(options);
+          const honey = new libhoney(options);
 
-      let transmission = honey.transmission;
+          const transmission = honey.transmission;
 
-      expect(options.a).toEqual(transmission.constructorArg.a);
-      expect(options.b).toEqual(transmission.constructorArg.b);
-      expect(options.c).toEqual(transmission.constructorArg.c);
-      expect(options.d).toEqual(transmission.constructorArg.d);
-    });
+          expect(options.a).toEqual(transmission.constructorArg.a);
+          expect(options.b).toEqual(transmission.constructorArg.b);
+          expect(options.c).toEqual(transmission.constructorArg.c);
+          expect(options.d).toEqual(transmission.constructorArg.d);
+        });
+      }
+    );
   });
 
   describe("event properties", () => {

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -39,7 +39,7 @@ describe("base transmission", () => {
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
-        postData: JSON.stringify({ a: 1, b: 2 })
+        postData: { a: 1, b: 2 }
       })
     );
   });
@@ -66,7 +66,7 @@ describe("base transmission", () => {
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
-        postData: JSON.stringify({ a: 1, b: 2 })
+        postData: { a: 1, b: 2 }
       })
     );
   });
@@ -104,7 +104,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 1,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     }
@@ -134,7 +134,7 @@ describe("base transmission", () => {
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
-        postData: JSON.stringify({ a: 1, b: 2 })
+        postData: { a: 1, b: 2 }
       })
     );
   });
@@ -154,7 +154,7 @@ describe("base transmission", () => {
         dataset: "test-transmission",
         sampleRate: 1,
         timestamp: new Date(),
-        postData: JSON.stringify({ a: 1, b: 2 })
+        postData: { a: 1, b: 2 }
       })
     );
   });
@@ -177,7 +177,7 @@ describe("base transmission", () => {
         dataset: "test-transmission",
         sampleRate: 10,
         timestamp: new Date(),
-        postData: JSON.stringify({ a: 1, b: 2 })
+        postData: { a: 1, b: 2 }
       })
     );
   });
@@ -199,7 +199,7 @@ describe("base transmission", () => {
         dataset: "test-transmission",
         sampleRate: 10,
         timestamp: new Date(),
-        postData: JSON.stringify({ a: 1, b: 2 })
+        postData: { a: 1, b: 2 }
       })
     );
   });
@@ -241,7 +241,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 1,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     }
@@ -257,7 +257,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 1,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
       expect(eventDropped).toBe(true);
@@ -295,7 +295,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 1,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     }
@@ -335,7 +335,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 1,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     }
@@ -372,7 +372,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 1,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     }
@@ -411,7 +411,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 10,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     }
@@ -439,8 +439,6 @@ describe("base transmission", () => {
       }
     });
 
-    let a = {};
-    a.a = a;
     for (let i = 0; i < 5; i++) {
       transmission.sendPresampledEvent(
         new ValidatedEvent({
@@ -449,7 +447,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 10,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     }
@@ -463,8 +461,8 @@ describe("base transmission", () => {
           writeKey: "123456789",
           dataset: "test-transmission",
           sampleRate: 10,
-          timestamp: b,
-          postData: JSON.stringify({ a: 1, b: 2 })
+          timestamp: new Date(),
+          postData: b
         })
       );
     }
@@ -476,7 +474,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 10,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     }
@@ -510,7 +508,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 1,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     }
@@ -572,7 +570,7 @@ describe("base transmission", () => {
           dataset: userAgent.dataset,
           sampleRate: 1,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 })
+          postData: { a: 1, b: 2 }
         })
       );
     });
@@ -610,7 +608,7 @@ describe("base transmission", () => {
         dataset: "browser-test",
         sampleRate: 1,
         timestamp: new Date(),
-        postData: JSON.stringify({ a: 1, b: 2 })
+        postData: { a: 1, b: 2 }
       })
     );
   });
@@ -671,7 +669,7 @@ describe("base transmission", () => {
           dataset: "test-transmission",
           sampleRate: 1,
           timestamp: new Date(),
-          postData: JSON.stringify({ a: 1, b: 2 }),
+          postData: { a: 1, b: 2 },
           metadata: "my metadata"
         })
       );


### PR DESCRIPTION
Looking at https://github.com/honeycombio/libhoney-js/blob/bf545810b604731d48be2e01dee07a039e90cf5d/src/transmission.js#L127 and https://github.com/honeycombio/libhoney-js/blob/bf545810b604731d48be2e01dee07a039e90cf5d/src/libhoney.js#L289 , `postData` is supposed to be an object, not a string. This change fixes the unit tests to match that behaviour and not stringify the `postData` before passing it to `ValidatedEvent`.

There's also a small change around the unstringifyable content, making sure that self-referencing object actually goes into the `postData`.

This also adds a separate change to test libhoney's option to provide a transmission constructor.