### PR TITLE
Bump version - I published 2.2.3 manually as a hotfix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,8 @@ workflows:
           context: Honeycomb Secrets for Public Repos
           requires:
             - build_artifacts
-      - publish_npm:
-          <<: *filters_publish
-          context: Honeycomb Secrets for Public Repos
-          requires:
-            - test
+#      - publish_npm:
+#          <<: *filters_publish
+#          context: Honeycomb Secrets for Public Repos
+#          requires:
+#            - test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libhoney",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": " Honeycomb.io Javascript library",
   "bugs": "https://github.com/honeycombio/libhoney-js/issues",
   "repository": {


### PR DESCRIPTION
- https://github.com/honeycombio/libhoney-js/issues/107
- remove the npm publish step from CI until it's fixed