### PR TITLE
fix npm publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: yarn
       - run: yarn build
-      - run: npm publish --dry-run
+      - run: npm publish
 
 workflows:
   nightly:
@@ -142,7 +142,7 @@ workflows:
           requires:
             - build_artifacts
       - publish_npm:
-          <<: *filters_always
+          <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,8 @@ jobs:
           name: store npm auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: yarn
-      - run: npm publish
+      - run: yarn build
+      - run: npm publish --dry-run
 
 workflows:
   nightly:
@@ -140,8 +141,8 @@ workflows:
           context: Honeycomb Secrets for Public Repos
           requires:
             - build_artifacts
-#      - publish_npm:
-#          <<: *filters_publish
-#          context: Honeycomb Secrets for Public Repos
-#          requires:
-#            - test
+      - publish_npm:
+          <<: *filters_always
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - test


### PR DESCRIPTION
- package entrypoints for libhoney are in the /dist (rollup artifacts)
- need to `yarn build` so they exist when publishing
- see output from a dry run: https://app.circleci.com/pipelines/github/honeycombio/libhoney-js/381/workflows/f8c49d3c-5833-4ddd-b147-6089e3a0a01c/jobs/2144