### PR TITLE
Add node 16 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ filters_publish: &filters_publish
 matrix_nodeversions: &matrix_nodeversions
   matrix:
     parameters:
-      nodeversion: ["8", "10", "11", "12", "14", "15"]
+      nodeversion: ["8", "10", "11", "12", "14", "15", "16"]
 
 # Default version of node to use for lint and publishing
 default_nodeversion: &default_nodeversion "12"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ filters_publish: &filters_publish
 matrix_nodeversions: &matrix_nodeversions
   matrix:
     parameters:
-      nodeversion: ["8", "10", "11", "12", "14", "15", "16"]
+      nodeversion: ["8.17", "10.24", "12.22", "14.17", "15.14", "16.2"]
 
 # Default version of node to use for lint and publishing
-default_nodeversion: &default_nodeversion "12"
+default_nodeversion: &default_nodeversion "12.22"
 
 executors:
   node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ executors:
         type: string
         default: *default_nodeversion
     docker:
-      - image: circleci/node:<< parameters.nodeversion >>
+      - image: cimg/node:<< parameters.nodeversion >>
   github:
     docker:
       - image: cibuilds/github:0.13.0


### PR DESCRIPTION
A few changes here:
- switch to [cimg](https://github.com/CircleCI-Public/cimg-overview) for docker images. This supercedes the previous `circleci` images, which don't have an image for node 16.
- `cimg` images don't have tags for just major versions, so specifying latest available minor versions
- dropping node 11 from the matrix because there's no image for it, and odd versions are kind of "temporary" in the node world, until next even version becomes "active": https://nodesource.com/blog/understanding-how-node-js-release-lines-work/