### PR TITLE
fix: remove yarn from engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "url": "https://github.com/honeycombio/libhoney-js.git"
   },
   "engines": {
-    "node": "8.* || >= 10.*",
-    "yarn": "YARN NO LONGER USED - use npm instead."
+    "node": "8.* || >= 10.*"
   },
   "browser": "dist/libhoney.browser.js",
   "module": "dist/libhoney.es.js",


### PR DESCRIPTION
Consumers of libhoney-js should be able to use yarn (fixes #169).