### PR TITLE
bump vm2 from 3.9.3 to 3.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10039,9 +10039,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
-      "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz",
+      "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==",
       "bin": {
         "vm2": "bin/vm2"
       },
@@ -17900,9 +17900,9 @@
       }
     },
     "vm2": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
-      "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q=="
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz",
+      "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- https://github.com/honeycombio/libhoney-js/security/dependabot/package-lock.json/vm2/open
- updates https://github.com/honeycombio/telemetry-team/issues/163

## Short description of the changes

- https://github.com/patriksimek/vm2/releases
- this only updates the lock file, so not a user-facing change (users could already lock to a safe version)

