### PR TITLE
maint: remove unused script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,24 +31,6 @@
   },
   "author": "",
   "license": "Apache-2.0",
-  "lint-staged": {
-    "*.{js,jsx}": [
-      "prettier --write",
-      "eslint"
-    ],
-    "*.json": [
-      "prettier --write"
-    ],
-    "*.{graphql,gql}": [
-      "prettier --write"
-    ],
-    "*.{md,markdown}": [
-      "prettier --write"
-    ],
-    "*.{css,scss}": [
-      "prettier --write"
-    ]
-  },
   "devDependencies": {
     "@babel/core": "^7.4.0",
     "@babel/eslint-parser": "^7.15.8",


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- #246 removed pre-commit linting, we don't need the lint-staged script anymore

## Short description of the changes

- YEET

