### PR TITLE
Handle `null` transmission in `flush`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "jest": "^27.2.4",
     "jest-in-case": "^1.0.2",
     "prettier": "^2.3.1",
+    "regenerator-runtime": "^0.13.9",
     "rollup": "^2.58.0",
     "superagent-mocker": "^0.5.2"
   },
@@ -57,6 +58,9 @@
     "https-proxy-agent": "^3.0.0"
   },
   "jest": {
+    "setupFilesAfterEnv": [
+      "./setupTests.js"
+    ],
     "testPathIgnorePatterns": [
       "dist/",
       "/node_modules/"

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,1 @@
+import "regenerator-runtime/runtime";

--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -154,7 +154,7 @@ describe("libhoney", () => {
   });
 
   describe("disabled = true", () => {
-    it("should not hit transmission", () => {
+    it("should not hit transmission", async () => {
       let honey = new libhoney({
         // these two properties are required
         writeKey: "12345",
@@ -165,6 +165,7 @@ describe("libhoney", () => {
       let transmission = honey.transmission;
 
       expect(transmission).toBe(null);
+      await expect(honey.flush()).resolves.toBeUndefined();
     });
   });
 });

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -457,6 +457,10 @@ export default class Libhoney extends EventEmitter {
       this._options
     );
 
+    if (!transmission) {
+      return Promise.resolve();
+    }
+    
     return transmission.flush();
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- calling `honey.flush()` when `honey` was instantiated with `disabled: true` throws an error
    ```
	  TypeError: Cannot read properties of null (reading 'flush')
	      at Libhoney.flush (/Users/sjchmiela/Developer/luma/node_modules/.pnpm/libhoney@3.1.0/node_modules/libhoney/dist/libhoney.cjs.js:1400:25)
	      at null.runJob (/Users/sjchmiela/Developer/luma/server/src/services/job-runner.ts:98:17)
	      at processTicksAndRejections (node:internal/process/task_queues:96:5)
	```

## Short description of the changes

- `transmission` may be `null` if `options.disabled` is true, as per https://github.com/honeycombio/libhoney-js/blob/177a17bcb311ea6988f3e0ebd24e15b4f316d3a9/src/libhoney.js#L493-L496 — we should check if `transmission` exists before calling `.flush` on it.

