### PR TITLE
maint: add node 18 to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ filters_publish: &filters_publish
 matrix_nodeversions: &matrix_nodeversions
   matrix:
     parameters:
-      nodeversion: ["12.22", "14.17", "15.14", "16.2", "17.0"]
+      nodeversion: ["12.22", "14.17", "15.14", "16.2", "17.0", "18.0"]
 
 # Default version of node to use for lint and publishing
-default_nodeversion: &default_nodeversion "12.22"
+default_nodeversion: &default_nodeversion "14.17"
 
 executors:
   node:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- node 18 has been out since April 😁 

## Short description of the changes

- test node 18 in CI
- also update default version to one that's in maintenance LTS

