### PR TITLE
Updated env variable naming in examples: HONEY_WRITE_KEY to HONEYCOMB_API_KEY

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ To build and run these examples:
 1. `cd $example-dir`
 1. `npm install ../.. # this installs the libhoney you built above`
 1. `npm install`
-1. `HONEY_WRITE_KEY=YOUR_WRITE_KEY npm start`
+1. `HONEYCOMB_API_KEY=YOUR_WRITE_KEY npm start`
 
 In a different terminal, you can then `curl --get http://localhost:3000/` to send a request to the running example,
 and then see the resulting telemetry at ui.honeycomb.io.

--- a/examples/express-dynamic-fields/app.js
+++ b/examples/express-dynamic-fields/app.js
@@ -5,7 +5,7 @@ const app = express();
 
 app.use(
   honey({
-    writeKey: process.env["HONEY_WRITE_KEY"],
+    writeKey: process.env["HONEYCOMB_API_KEY"],
     dataset: "express-example-dynamic-fields",
     sampleRate: 5 // log 1 out of every 5 events
   })

--- a/examples/express-response-time/app.js
+++ b/examples/express-response-time/app.js
@@ -5,7 +5,7 @@ const responseTime = require("response-time");
 let app = express();
 
 let honey = new libhoney({
-  writeKey: process.env["HONEY_WRITE_KEY"],
+  writeKey: process.env["HONEYCOMB_API_KEY"],
   dataset: "express-example-response-time"
 });
 

--- a/examples/express/app.js
+++ b/examples/express/app.js
@@ -5,7 +5,7 @@ let app = express();
 
 app.use(
   honey({
-    writeKey: process.env["HONEY_WRITE_KEY"],
+    writeKey: process.env["HONEYCOMB_API_KEY"],
     dataset: "express-example"
   })
 );


### PR DESCRIPTION


<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

 I noticed the env variable in the example app `HONEY_WRITE_KEY` was different than what most of our examples used, `HONEYCOMB_API_KEY`, so I changed it to be consistent :) prevents having to stop and change .env files or any CLI habits being used in development
