### PR TITLE
Set circleCI node default to latest v16; bump node version matrix to latest minor releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ filters_publish: &filters_publish
 matrix_nodeversions: &matrix_nodeversions
   matrix:
     parameters:
-      nodeversion: ["14.17", "16.2", "18.0"]
+      nodeversion: ["14.20", "16.17", "18.9"]
 
 # Default version of node to use for lint and publishing
-default_nodeversion: &default_nodeversion "14.17"
+default_nodeversion: &default_nodeversion "16.17"
 
 executors:
   node:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- bump CircleCI to only test latest node v14, v16, v18 (current security supported node versions)
- Set circleCI default to latest v16 (14 is in process of EOL in the next several months)


