### PR TITLE
[release] Prepare 4.4.0 - Drop Node 12 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # libhoney-js changelog
 
+
+## [4.0.0] - 2022-09-19
+
+### !!! Breaking Changes !!!
+
+- Drop Node v12, no longer security supported (#308) | [@emilyashley](https://github.com/emilyashley)
+
+### Maintenance
+
+- Set circleCI Node default to latest v16 (#310) | [@emilyashley](https://github.com/emilyashley)
+  
 ## [3.1.2] - 2022-09-13
 
 ### Maintenance

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 1. Add release entry to [changelog](./CHANGELOG.md)
 2. Update version using `npm version --no-git-tag-version patch` (replace patch with minor / major as needed)
 3. Open a PR with the above, and merge that into main
-4. Create new tag on merged commit with the new version (e.g. `v2.3.1`)
-5. Push the tag upstream (this will kick off the release pipeline in CI)
+4. Create new tag on merged commit with the new version (e.g. `git tag -a v2.3.1 -m "v2.3.1"`)
+5. Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v2.3.1`
 6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
+   - generate release notes via github release draft for full changelog notes and any new contributors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libhoney",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libhoney",
-      "version": "3.1.2",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "superagent": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libhoney",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "description": " Honeycomb.io Javascript library",
   "bugs": "https://github.com/honeycombio/libhoney-js/issues",
   "repository": {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Release:
- Drop Node v12, no longer security supported (#308)
- Set circleCI Node default to latest v16 (#310)

also added cli commands to release.md for easy reference, similar to libhoney-py.