### PR TITLE
fix: Use url-join instead of urljoin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,2 @@
-module.exports = {
-  "presets": [
-    "@babel/preset-env",
-  ]
-}
+/* eslint-env node */
+module.exports = { presets: ["@babel/preset-env"] };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "presets": [
     "@babel/preset-env",
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "superagent": "^8.0.0",
         "superagent-proxy": "^3.0.0",
-        "urljoin": "^0.1.5"
+        "url-join": "^5.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.4.0",
@@ -8162,18 +8162,13 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/urljoin": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/urljoin/-/urljoin-0.1.5.tgz",
-      "integrity": "sha1-sl0sYRLFWsnVAJakmg8ft/T1OSE=",
-      "dependencies": {
-        "extend": "~2.0.0"
+    "node_modules/url-join": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
-    },
-    "node_modules/urljoin/node_modules/extend": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
-      "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -14374,20 +14369,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "urljoin": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/urljoin/-/urljoin-0.1.5.tgz",
-      "integrity": "sha1-sl0sYRLFWsnVAJakmg8ft/T1OSE=",
-      "requires": {
-        "extend": "~2.0.0"
-      },
-      "dependencies": {
-        "extend": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
-          "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
-        }
-      }
+    "url-join": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "superagent": "^8.0.0",
     "superagent-proxy": "^3.0.0",
-    "urljoin": "^0.1.5"
+    "url-join": "^5.0.0"
   },
   "resolutions": {
     "https-proxy-agent": "^3.0.0"
@@ -61,6 +61,7 @@
     "setupFilesAfterEnv": [
       "./setupTests.js"
     ],
+    "transformIgnorePatterns": ["/node_modules/(?!url-join)"],
     "testPathIgnorePatterns": [
       "dist/",
       "/node_modules/"

--- a/src/transmission.js
+++ b/src/transmission.js
@@ -8,7 +8,7 @@
  * @module
  */
 import superagent from "superagent";
-import urljoin from "urljoin";
+import urlJoin from "url-join";
 
 const LIBHONEY_VERSION = "libhoney-js/<@LIBHONEY_JS_VERSION@>";
 const NODE_VERSION = `node/${process.version}`;
@@ -326,7 +326,7 @@ export class Transmission {
 
     let batches = Object.keys(batchAgg.batches).map(k => batchAgg.batches[k]);
     eachPromise(batches, batch => {
-      let url = urljoin(batch.apiHost, "/1/batch", batch.dataset);
+      let url = urlJoin(batch.apiHost, "/1/batch", batch.dataset);
       let postReq = superagent.post(url);
 
       let reqPromise;


### PR DESCRIPTION
## Which problem is this PR solving?

libhoney is pulling in a helper library called urljoin to fuse URL components together. urljoin expects to be run in a Node environment, and uses the Node standard library (notably the path module). Because of this dependency, libhoney fails for us when run under Webpack 5, which no longer bundles Node libraries in.

## Short description of the changes

This PR swaps urljoin out for an alternative library with equivalent functionality, called url-join. url-join has no dependencies, and is newer than urljoin and still maintained.

Because it's new, it uses ES Modules; I needed to configure Jest to use Babel to transform it.

