### PR TITLE
maint: extra test to check for http info from proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  test:
+    image: node:${NODE_VERSION:-16}-slim # Node 16 by default; "NODE_VERSION=<ver> docker-compose up" to run something different
+    user: node
+    working_dir: /home/node/app
+    volumes:
+      - ./:/home/node/app
+    command: /bin/sh -c "while sleep 1000; do :; done" # idle, use "docker-compose exec test npm <command>" after this is started
+    ports:
+      - 127.0.0.1:3000:3000
+
+  squid:
+    image: ubuntu/squid
+    environment:
+      - TZ=UTC
+    ports:
+      - 127.0.0.1:3128:3128
+
+  socks:
+    image: serjs/go-socks5-proxy
+    ports:
+      - 127.0.0.1:1080:1080

--- a/examples/express/app.js
+++ b/examples/express/app.js
@@ -6,6 +6,7 @@ let app = express();
 app.use(
   honey({
     writeKey: process.env["HONEYCOMB_API_KEY"],
+    // proxy: "http://localhost:3128",
     dataset: "express-example"
   })
 );

--- a/examples/express/express-honey.js
+++ b/examples/express/express-honey.js
@@ -27,7 +27,9 @@ module.exports = function(options) {
       query: req.query,
       route: req.route,
       secure: req.secure,
-      xhr: req.xhr
+      xhr: req.xhr,
+      dataset: honey._options.dataset || "express-example",
+      proxy: honey._options.proxy || "none",
     });
     next();
   };

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -56,7 +56,7 @@ describe("base transmission", () => {
       expect(req.method).toBe("POST");
       expect(req.headers["x-honeycomb-team"]).toBe("123456789");
       proxyServer.close(() => {
-        proxyServer.removeAllListeners()
+        proxyServer.removeAllListeners();
         done();
       });
     });
@@ -575,7 +575,7 @@ describe("base transmission", () => {
         probe: userAgent =>
         // user-agent order: libhoney, addition, node
           userAgent.indexOf("libhoney-js/<@LIBHONEY_JS_VERSION@>") === 0 &&
-          userAgent.indexOf("addition") < userAgent.indexOf(`node/${process.version}`) 
+          userAgent.indexOf("addition") < userAgent.indexOf(`node/${process.version}`)
       }
     ];
 

--- a/src/__tests__/transmission_test.js
+++ b/src/__tests__/transmission_test.js
@@ -48,6 +48,40 @@ describe("base transmission", () => {
     );
   });
 
+  it("will share its http info with a proxy", done => {
+    const proxyServer = http.createServer((req, res) => {
+      res.writeHead(418, { "Content-Type": "application/json" });
+      res.end("[{ status: 418 }]");
+      expect(req.headers.host).toBe("localhost:1234");
+      expect(req.method).toBe("POST");
+      expect(req.headers["x-honeycomb-team"]).toBe("123456789");
+      proxyServer.close(() => {
+        proxyServer.removeAllListeners()
+        done();
+      });
+    });
+
+    proxyServer.listen(9998, "127.0.0.1");
+
+    let transmission = new Transmission({
+      proxy: "http://127.0.0.1:9998",
+      batchTimeTrigger: 10000, // larger than the mocha timeout
+      batchSizeTrigger: 0,
+    });
+
+
+    transmission.sendEvent(
+      new ValidatedEvent({
+        apiHost: "http://localhost:1234",
+        writeKey: "123456789",
+        dataset: "test-transmission",
+        sampleRate: 1,
+        timestamp: new Date(),
+        postData: { a: 1, b: 2 }
+      })
+    );
+  });
+
   it("should handle batchSizeTrigger of 0", done => {
     mock.post("http://localhost:9999/1/events/test-transmission", req => {
       let reqEvents = JSON.parse(req.body);


### PR DESCRIPTION
## Which problem is this PR solving?

- adding a bit more confidence in unit testing for proxy usage as a follow-up from #389 

## Short description of the changes

- extra test that confirms http headers and method are passed along to the proxy server
- optional: added docker-compose for easy spinning up of proxies, along with some extra attributes for event if the proxy is in use.

