### PR TITLE
feat: support classic ingest keys

### DIFF
--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -94,6 +94,28 @@ describe("libhoney", () => {
       );
     });
 
+    it("should reject a send from an empty dataset with a classic v3 key", () => {
+      // mock out console.error
+      console.error = jest.fn();
+
+      const classicv3IngestKey = "hcaic_1234567890123456789012345678901234567890123456789012345678";
+
+      let honey = new libhoney({
+        apiHost: "http://foo/bar",
+        writeKey: classicv3IngestKey,
+        dataset: "",
+        transmission: "mock",
+      });
+      let transmission = honey.transmission;
+      let postData = { a: 1, b: 2 };
+      honey.sendNow(postData);
+
+      expect(transmission.events).toHaveLength(0);
+      expect(console.error.mock.calls[0][0]).toBe(
+        "dataset must be a non-empty string"
+      );
+    });
+
     it("should set an empty dataset to unknown_dataset with a V2 key", () => {
       let honey = new libhoney({
         apiHost: "http://foo/bar",

--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -1,6 +1,6 @@
 /* eslint-env node, jest */
-import { MockTransmission } from "../transmission";
-import libhoney from "../libhoney";
+import libhoney, {isClassic} from "../libhoney";
+import {MockTransmission} from "../transmission";
 
 let superagent = require("superagent");
 let mock = require("superagent-mocker")(superagent);
@@ -41,7 +41,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = { a: 1, b: 2 };
+      let postData = {a: 1, b: 2};
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(1);
@@ -64,7 +64,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = { a: 1, b: 2 };
+      let postData = {a: 1, b: 2};
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(1);
@@ -85,7 +85,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = { a: 1, b: 2 };
+      let postData = {a: 1, b: 2};
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(0);
@@ -107,7 +107,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = { a: 1, b: 2 };
+      let postData = {a: 1, b: 2};
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(0);
@@ -124,7 +124,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = { a: 1, b: 2 };
+      let postData = {a: 1, b: 2};
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(1);
@@ -168,7 +168,7 @@ describe("libhoney", () => {
 
       for (let i = 0; i < queueSize + 1; i++) {
         let ev = honey.newEvent();
-        ev.add({ a: 1, b: 2 });
+        ev.add({a: 1, b: 2});
         ev.addMetadata(i);
         ev.send();
       }
@@ -189,5 +189,43 @@ describe("libhoney", () => {
       expect(transmission).toBe(null);
       await expect(honey.flush()).resolves.toBeUndefined();
     });
+  });
+});
+
+describe("isClassic check", () => {
+  it.each([
+    {
+      testString: "hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc",
+      name: "full ingest key string, non classic",
+      expected: false
+    },
+    {
+      testString: "hcxik_01hqk4k20cjeh63wca8vva5stw",
+      name: "ingest key id, non classic",
+      expected: false
+    },
+    {
+      testString: "hcaic_1234567890123456789012345678901234567890123456789012345678",
+      name: "full ingest key string, classic",
+      expected: true
+    },
+    {
+      testString: "hcaic_12345678901234567890123456",
+      name: "ingest key id, classic",
+      expected: false
+    },
+    {
+      testString: "kgvSpPwegJshQkuowXReLD",
+      name: "v2 configuration key",
+      expected: false
+    },
+    {
+      testString: "12345678901234567890123456789012",
+      name: "classic key",
+      expected: true
+    },
+
+  ])("test case $name", (testCase) => {
+    expect(isClassic(testCase.testString)).toEqual(testCase.expected);
   });
 });

--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -224,6 +224,11 @@ describe("isClassic check", () => {
       name: "classic key",
       expected: true
     },
+    {
+      testString: "",
+      name: "no key",
+      expected: true
+    }
 
   ])("test case $name", (testCase) => {
     expect(libhoney.isClassic(testCase.testString)).toEqual(testCase.expected);

--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -1,6 +1,6 @@
 /* eslint-env node, jest */
-import libhoney, {isClassic} from "../libhoney";
-import {MockTransmission} from "../transmission";
+import { MockTransmission } from "../transmission";
+import libhoney from "../libhoney";
 
 let superagent = require("superagent");
 let mock = require("superagent-mocker")(superagent);
@@ -41,7 +41,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = {a: 1, b: 2};
+      let postData = { a: 1, b: 2 };
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(1);
@@ -64,7 +64,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = {a: 1, b: 2};
+      let postData = { a: 1, b: 2 };
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(1);
@@ -85,7 +85,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = {a: 1, b: 2};
+      let postData = { a: 1, b: 2 };
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(0);
@@ -107,7 +107,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = {a: 1, b: 2};
+      let postData = { a: 1, b: 2 };
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(0);
@@ -124,7 +124,7 @@ describe("libhoney", () => {
         transmission: "mock",
       });
       let transmission = honey.transmission;
-      let postData = {a: 1, b: 2};
+      let postData = { a: 1, b: 2 };
       honey.sendNow(postData);
 
       expect(transmission.events).toHaveLength(1);
@@ -168,7 +168,7 @@ describe("libhoney", () => {
 
       for (let i = 0; i < queueSize + 1; i++) {
         let ev = honey.newEvent();
-        ev.add({a: 1, b: 2});
+        ev.add({ a: 1, b: 2 });
         ev.addMetadata(i);
         ev.send();
       }
@@ -226,6 +226,6 @@ describe("isClassic check", () => {
     },
 
   ])("test case $name", (testCase) => {
-    expect(isClassic(testCase.testString)).toEqual(testCase.expected);
+    expect(libhoney.isClassic(testCase.testString)).toEqual(testCase.expected);
   });
 });

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -563,19 +563,17 @@ function concatWithMaxLimit(arr1, arr2, limit) {
 
 
 /**
- * isClassic takes an API key and returns true if it is a "classic" APIKey,
- * namely, that its length is exactly 32 characters.
+ * isClassic takes an API key and returns true if it is a "classic" Configuration API Key or Ingest API Key.
  * @returns {boolean} whether the key is classic
  *
+ * @example
+ *   if(isClassic(apiKey)) {
+ *     // special case for classic environments
+ *   }
  */
-// todo: add example? and/or move to a different export
 
-const ingestKeyRegex = /^hc[a-z]i._/;
-const classicKeyRegex = /^hc[a-z]ic_/;
+const classicKeyRegex = /^[a-z0-9]{32}$/;
+const ingestClassicKeyRegex = /^hc[a-z]ic_[a-z0-9]{58}/;
 export function isClassic(key) {
-  if (key.length === 32) {
-    return !ingestKeyRegex.test(key);
-  } else {
-    return classicKeyRegex.test(key);
-  }
+  return classicKeyRegex.test(key) || ingestClassicKeyRegex.test(key);
 }

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -19,8 +19,8 @@ import Builder from "./builder";
 
 import { EventEmitter } from "events";
 
-const classicKeyRegex = /^[a-z0-9]{32}$/;
-const ingestClassicKeyRegex = /^hc[a-z]ic_[a-z0-9]{58}/;
+const classicKeyRegex = /^[a-f0-9]*$/;
+const ingestClassicKeyRegex = /^hc[a-z]ic_[a-z0-9]*$/;
 
 const defaults = Object.freeze({
   apiHost: "https://api.honeycomb.io/",
@@ -281,7 +281,15 @@ export default class Libhoney extends EventEmitter {
    *   }
    */
   static isClassic(key) {
-    return classicKeyRegex.test(key) || ingestClassicKeyRegex.test(key);
+    if (key === null || key === undefined || key.length === 0) {
+      return true;
+    }
+    else if(key.length === 32) {
+      return classicKeyRegex.test(key);
+    } else if(key.length === 64) {
+      return ingestClassicKeyRegex.test(key);
+    }
+    return false;
   }
 
   /**

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -276,8 +276,7 @@ export default class Libhoney extends EventEmitter {
    */
   // todo: add example? and/or move to a different export
   isClassic(key) {
-    const keyRegex = /^hc[a-z]ic_/;
-    return key.length === 32 || keyRegex.test(key);
+    return isClassic(key);
   }
 
   /**
@@ -560,4 +559,23 @@ function concatWithMaxLimit(arr1, arr2, limit) {
 
   // otherwise assume it'll all fit, combine the responses with the queue
   return arr1.concat(arr2);
+}
+
+
+/**
+ * isClassic takes an API key and returns true if it is a "classic" APIKey,
+ * namely, that its length is exactly 32 characters.
+ * @returns {boolean} whether the key is classic
+ *
+ */
+// todo: add example? and/or move to a different export
+
+const ingestKeyRegex = /^hc[a-z]i._/;
+const classicKeyRegex = /^hc[a-z]ic_/;
+export function isClassic(key) {
+  if (key.length === 32) {
+    return !ingestKeyRegex.test(key);
+  } else {
+    return classicKeyRegex.test(key);
+  }
 }

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -19,6 +19,9 @@ import Builder from "./builder";
 
 import { EventEmitter } from "events";
 
+const classicKeyRegex = /^[a-z0-9]{32}$/;
+const ingestClassicKeyRegex = /^hc[a-z]ic_[a-z0-9]{58}/;
+
 const defaults = Object.freeze({
   apiHost: "https://api.honeycomb.io/",
 
@@ -269,14 +272,16 @@ export default class Libhoney extends EventEmitter {
   }
 
   /**
-   * isClassic takes a writeKey and returns true if it is a "classic" writeKey,
-   * namely, that its length is exactly 32 characters.
+   * isClassic takes an API key and returns true if it is a "classic" Configuration API Key or Ingest API Key.
    * @returns {boolean} whether the key is classic
    *
+   * @example
+   *   if(libhoney.isClassic(apiKey)) {
+   *     // special case for classic environments
+   *   }
    */
-  // todo: add example? and/or move to a different export
-  isClassic(key) {
-    return isClassic(key);
+  static isClassic(key) {
+    return classicKeyRegex.test(key) || ingestClassicKeyRegex.test(key);
   }
 
   /**
@@ -324,7 +329,7 @@ export default class Libhoney extends EventEmitter {
     }
 
     if (dataset === "") {
-      if (this.isClassic(writeKey)) {
+      if (Libhoney.isClassic(writeKey)) {
         console.error("dataset must be a non-empty string");
         return null;
       } else {
@@ -559,21 +564,4 @@ function concatWithMaxLimit(arr1, arr2, limit) {
 
   // otherwise assume it'll all fit, combine the responses with the queue
   return arr1.concat(arr2);
-}
-
-
-/**
- * isClassic takes an API key and returns true if it is a "classic" Configuration API Key or Ingest API Key.
- * @returns {boolean} whether the key is classic
- *
- * @example
- *   if(isClassic(apiKey)) {
- *     // special case for classic environments
- *   }
- */
-
-const classicKeyRegex = /^[a-z0-9]{32}$/;
-const ingestClassicKeyRegex = /^hc[a-z]ic_[a-z0-9]{58}/;
-export function isClassic(key) {
-  return classicKeyRegex.test(key) || ingestClassicKeyRegex.test(key);
 }

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -273,10 +273,11 @@ export default class Libhoney extends EventEmitter {
    * namely, that its length is exactly 32 characters.
    * @returns {boolean} whether the key is classic
    *
-   * @private
    */
+  // todo: add example? and/or move to a different export
   isClassic(key) {
-    return key.length === 32;
+    const keyRegex = /^hc[a-z]ic_/;
+    return key.length === 32 || keyRegex.test(key);
   }
 
   /**
@@ -460,7 +461,7 @@ export default class Libhoney extends EventEmitter {
     if (!transmission) {
       return Promise.resolve();
     }
-    
+
     return transmission.flush();
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

We've released Ingest Keys, but need to update the key detection logic to allow Ingest Keys to be used to send data to Classic environments.

## Short description of the changes
- updates the Classic API Key detection logic to understand the shape of a Classic Ingest Key
- Changes `isClassic` from a "private" class method of `Libhoney` to a static class method, so we can reuse it in dependent libraries without repeating logic everywhere 

