### PR TITLE
rel: Prepare v4.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # libhoney-js changelog
 
+## [4.3.0] - 2024-04-25
+
+### Maintenance
+
+- maint: Update ubuntu image in workflows to latest (#409) | @MikeGoldsmith
+- maint: Add labels to release.yml for auto-generated grouping (#408) | @JamieDanielson
+- maint(deps): bump formidable and superagent (#414) | @dependabot
+- maint(deps): bump ip from 1.1.8 to 1.1.9 (#413) | @dependabot
+- maint(deps-dev): bump @babel/preset-env from 7.22.9 to 7.24.4 (#415) | @dependabot
+- maint(deps-dev): bump @babel/traverse from 7.22.8 to 7.24.1 (#412) | @dependabot
+- maint(deps-dev): bump @rollup/plugin-node-resolve from 15.1.0 to 15.2.3 (#402) | @dependabot
+- maint(deps-dev): bump @rollup/plugin-commonjs from 25.0.3 to 25.0.7 (#401) | @dependabot
+- maint(deps-dev): bump babel-jest from 29.6.2 to 29.7.0 (#398) | @dependabot
+- maint(deps-dev): bump jest from 29.5.0 to 29.7.0 (#399) | @dependabot
+
 ## [4.2.0] - 2024-02-28
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [4.3.0] - 2024-04-25
 
+### !!! Breaking Changes !!!
+
+Minimum Node version is now 14.18.
+
 ### Maintenance
 
 - maint: Update ubuntu image in workflows to latest (#409) | @MikeGoldsmith

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For tracing support and automatic instrumentation of Express and other common li
 
 ## Dependencies
 
-**Node 14+**
+**Node 14.18+**
 
 ## Contributions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libhoney",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libhoney",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "proxy-agent": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/honeycombio/libhoney-js.git"
   },
   "engines": {
-    "node": ">= 14.*"
+    "node": ">= 14.18"
   },
   "browser": "dist/libhoney.browser.js",
   "module": "dist/libhoney.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libhoney",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": " Honeycomb.io Javascript library",
   "bugs": "https://github.com/honeycombio/libhoney-js/issues",
   "repository": {


### PR DESCRIPTION
## Which problem is this PR solving?

Prepares the next release of libhoney-js.

## Short description of the changes

- Update version to 4.3.0
- Add changelog entry
- Update README with updated Node version (14.18)
- Update min node version in package.json

