### PR TITLE
ci: switch to OIDC token for npm publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,12 +114,11 @@ jobs:
       name: node
     steps:
       - checkout
-      - run:
-          name: store npm auth token
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: |
+          export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+          npm publish
 
 workflows:
   nightly:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/pipeline-team
+* @honeycombio/oss-maintainers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "libhoney",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "proxy-agent": "^6.3.0",


### PR DESCRIPTION
npmjs and CircleCI support OIDC token exchange† now, so do that‡ instead of the old token style auth.

[† supported CI/CD](https://docs.npmjs.com/trusted-publishers#supported-cicd-providers)
[‡ CircleCI config](https://docs.npmjs.com/trusted-publishers#circleci-configuration)

bonus: codeowner update to oss-maintainers

bonus bonus: a missed version bump from previous release