### PR TITLE
ci: followups to fix trusted publishing to npmjs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ filters_publish: &filters_publish
 matrix_nodeversions: &matrix_nodeversions
   matrix:
     parameters:
-      nodeversion: ["14.20", "16.17", "18.9"]
+      nodeversion: ["14.20", "16.17", "18.9", "20.20", "22.22", "24.15"]
 
 # Default version of node to use for lint and publishing
-default_nodeversion: &default_nodeversion "16.17"
+default_nodeversion: &default_nodeversion "24.15"
 
 executors:
   node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,8 @@ jobs:
       - run: npm run build
       - run: |
           export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
-          npm publish
+          [[ "${CIRCLE_TAG#v}" == *-* ]] && DIST_TAG="next" || DIST_TAG="latest"
+          npm publish --tag "$DIST_TAG"
 
 workflows:
   nightly:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libhoney",
-  "version": "4.3.1",
+  "version": "4.3.2-pre0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libhoney",
-      "version": "4.3.1",
+      "version": "4.3.2-pre0",
       "license": "Apache-2.0",
       "dependencies": {
         "proxy-agent": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libhoney",
-  "version": "4.3.1",
+  "version": "4.3.2-pre0",
   "description": " Honeycomb.io Javascript library",
   "bugs": "https://github.com/honeycombio/libhoney-js/issues",
   "repository": {


### PR DESCRIPTION
Followups on using NPMJS trusted publishing to get it to actually work.

* test and publish with a much newer Node: added 20, 22, 24 and defaulting to 24
  * Word on the street is that the OIDC support in npm started in a version newer than the one available in the Node 16 image. 😅 
* actually bump the version in package.json (with npm version) which the publish cares about as opposed to the repo's tag
* publishing a prerelease requires an explicit `--tag` option, so determine `latest` or `next` based on whether the tagged version contains a dash `-`