### PR TITLE
Add createMarker and deleteMarker

### DIFF
--- a/src/__tests__/libhoney_test.js
+++ b/src/__tests__/libhoney_test.js
@@ -190,6 +190,138 @@ describe("libhoney", () => {
       await expect(honey.flush()).resolves.toBeUndefined();
     });
   });
+
+  describe("createMarker", () => {
+    it("should post a marker to the configured apiHost and dataset", async () => {
+      expect.assertions(5);
+
+      mock.post("http://localhost:9999/1/markers/test-markers", (req) => {
+        expect(req.headers["x-honeycomb-team"]).toBe("12345");
+        expect(req.headers["content-type"]).toBe("application/json");
+        expect(req.body).toEqual({
+          message: "backend deploy #123",
+          type: "deploy"
+        });
+        return {
+          body: {
+            id: "marker-id",
+            message: "backend deploy #123",
+            type: "deploy",
+          }
+        };
+      });
+
+      let honey = new libhoney({
+        apiHost: "http://localhost:9999",
+        writeKey: "12345",
+        dataset: "events-dataset",
+        transmission: "mock",
+      });
+
+      let res = await honey.createMarker(
+        "test-markers",
+        "backend deploy #123",
+        "deploy"
+      );
+
+      expect(res.body.id).toBe("marker-id");
+      expect(res.body.type).toBe("deploy");
+    });
+
+    it("should reject an empty marker dataset without making a request", async () => {
+      let honey = new libhoney({
+        apiHost: "http://localhost:9999",
+        writeKey: "aKeySimilarToOurV2Keys",
+        dataset: "events-dataset",
+        transmission: "mock",
+      });
+
+      await expect(
+        honey.createMarker("", "backend deploy #123", "deploy")
+      ).rejects.toThrow("dataset must be a non-empty string");
+    });
+
+    it("should reject invalid marker values without making a request", async () => {
+      let honey = new libhoney({
+        apiHost: "http://localhost:9999",
+        writeKey: "12345",
+        dataset: "events-dataset",
+        transmission: "mock",
+      });
+
+      await expect(
+        honey.createMarker("test-markers", "", "deploy")
+      ).rejects.toThrow("message must be a non-empty string");
+    });
+
+    it("should not post a marker when disabled", async () => {
+      let honey = new libhoney({
+        apiHost: "http://localhost:9999",
+        writeKey: "12345",
+        dataset: "events-dataset",
+        transmission: "mock",
+        disabled: true,
+      });
+
+      await expect(
+        honey.createMarker("test-markers", "backend deploy #123", "deploy")
+      ).resolves.toBeUndefined();
+    });
+
+    it("should delete a marker from the configured apiHost and dataset", async () => {
+      expect.assertions(3);
+
+      mock.del("http://localhost:9999/1/markers/test-markers/marker-id", (req) => {
+        expect(req.headers["x-honeycomb-team"]).toBe("12345");
+        return {
+          body: {
+            id: "marker-id",
+            message: "backend deploy #123",
+            type: "deploy",
+          }
+        };
+      });
+
+      let honey = new libhoney({
+        apiHost: "http://localhost:9999",
+        writeKey: "12345",
+        dataset: "events-dataset",
+        transmission: "mock",
+      });
+
+      let res = await honey.deleteMarker("test-markers", "marker-id");
+
+      expect(res.body.id).toBe("marker-id");
+      expect(res.body.type).toBe("deploy");
+    });
+
+    it("should reject invalid marker ids without making a request", async () => {
+      let honey = new libhoney({
+        apiHost: "http://localhost:9999",
+        writeKey: "12345",
+        dataset: "events-dataset",
+        transmission: "mock",
+      });
+
+      await expect(
+        honey.deleteMarker("test-markers", "")
+      ).rejects.toThrow("markerId must be a non-empty string");
+    });
+
+    it("should not delete a marker when disabled", async () => {
+      let honey = new libhoney({
+        apiHost: "http://localhost:9999",
+        writeKey: "12345",
+        dataset: "events-dataset",
+        transmission: "mock",
+        disabled: true,
+      });
+
+      await expect(
+        honey.deleteMarker("test-markers", "marker-id")
+      ).resolves.toBeUndefined();
+    });
+  });
 });
 
 describe("isClassic check", () => {

--- a/src/libhoney.js
+++ b/src/libhoney.js
@@ -6,6 +6,7 @@
 /**
  * @module
  */
+/* eslint-disable sort-imports */
 import {
   ConsoleTransmission,
   MockTransmission,
@@ -16,8 +17,11 @@ import {
   WriterTransmission,
 } from "./transmission";
 import Builder from "./builder";
+import superagent from "superagent";
+import urlJoin from "url-join";
 
 import { EventEmitter } from "events";
+/* eslint-enable sort-imports */
 
 const classicKeyRegex = /^[a-f0-9]*$/;
 const ingestClassicKeyRegex = /^hc[a-z]ic_[a-z0-9]*$/;
@@ -428,6 +432,66 @@ export default class Libhoney extends EventEmitter {
   }
 
   /**
+   * creates a Marker for a dataset.
+   * @param {string} dataset the dataset where the marker should appear.
+   * @param {string} message the marker message.
+   * @param {string} type the marker type.
+   * @returns {Promise} a promise that resolves when Honeycomb responds to the marker creation request.
+   */
+  createMarker(dataset, message, type) {
+    if (this._options.disabled) {
+      return Promise.resolve();
+    }
+
+    let validationError = validateMarkerOptions(
+      this._builder.apiHost,
+      this._builder.writeKey,
+      dataset,
+      message,
+      type
+    );
+    if (validationError) {
+      return Promise.reject(validationError);
+    }
+
+    let url = urlJoin(this._builder.apiHost, "/1/markers", dataset);
+    return superagent
+      .post(url)
+      .set("X-Honeycomb-Team", this._builder.writeKey)
+      .type("json")
+      .timeout(this._options.timeout)
+      .send({ message, type });
+  }
+
+  /**
+   * deletes a Marker from a dataset.
+   * @param {string} dataset the dataset containing the marker.
+   * @param {string} markerId the id of the marker to delete.
+   * @returns {Promise} a promise that resolves when Honeycomb responds to the marker deletion request.
+   */
+  deleteMarker(dataset, markerId) {
+    if (this._options.disabled) {
+      return Promise.resolve();
+    }
+
+    let validationError = validateDeleteMarkerOptions(
+      this._builder.apiHost,
+      this._builder.writeKey,
+      dataset,
+      markerId
+    );
+    if (validationError) {
+      return Promise.reject(validationError);
+    }
+
+    let url = urlJoin(this._builder.apiHost, "/1/markers", dataset, markerId);
+    return superagent
+      .del(url)
+      .set("X-Honeycomb-Team", this._builder.writeKey)
+      .timeout(this._options.timeout);
+  }
+
+  /**
    * creates and returns a new Event containing all fields/dynFields from the global Builder, that can be further fleshed out and sent on its own.
    * @returns {Event} an Event instance
    * @example <caption>adding data at send-time</caption>
@@ -543,6 +607,49 @@ function getAndInitTransmission(transmission, options) {
       );
     }
   }
+}
+
+function validateMarkerOptions(apiHost, writeKey, dataset, message, type) {
+  let baseValidationError = validateMarkerRequestOptions(
+    apiHost,
+    writeKey,
+    dataset
+  );
+  if (baseValidationError) return baseValidationError;
+  if (typeof message !== "string" || message === "") {
+    return new Error("message must be a non-empty string");
+  }
+  if (typeof type !== "string" || type === "") {
+    return new Error("type must be a non-empty string");
+  }
+  return null;
+}
+
+function validateDeleteMarkerOptions(apiHost, writeKey, dataset, markerId) {
+  let baseValidationError = validateMarkerRequestOptions(
+    apiHost,
+    writeKey,
+    dataset
+  );
+  if (baseValidationError) return baseValidationError;
+  if (typeof markerId !== "string" || markerId === "") {
+    return new Error("markerId must be a non-empty string");
+  }
+  return null;
+}
+
+function validateMarkerRequestOptions(apiHost, writeKey, dataset) {
+  if (typeof apiHost !== "string" || apiHost === "") {
+    return new Error("apiHost must be a non-empty string");
+  }
+  if (typeof writeKey !== "string" || writeKey === "") {
+    return new Error("writeKey must be a non-empty string");
+  }
+  // Unlike event sends, marker creation/deletion requires a real dataset slug.
+  if (typeof dataset !== "string" || dataset === "") {
+    return new Error("dataset must be a non-empty string");
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
#### Summary
Adds basic marker support to libhoney-js.

- Adds createMarker(dataset, message, type)
- Adds deleteMarker(dataset, markerId)
- Validates marker inputs before making API requests
- Adds unit tests for marker create/delete behavior
- Adds a simple standalone smoke test for sending an event, creating a marker, and deleting it